### PR TITLE
Add coercion to str from num

### DIFF
--- a/csp_gateway/utils/struct/base.py
+++ b/csp_gateway/utils/struct/base.py
@@ -322,8 +322,20 @@ class GatewayStruct(PerspectiveUtilityMixin, Struct, metaclass=PydanticizedCspSt
 
     @classmethod
     def _validate_gateway_struct(cls, val):
-        # Custom entry point to inject model-level
-        # AFTER validation
+        """Validate GatewayStruct after pydantic type validation.
+
+        A validator attached to every GatewayStruct to allow for defining custom
+        model-level after validators that run after pydantic type validation.
+        If not defined on a child class, the parent's validator will be used.  If defined on a child class, the parent's validator will be ignored. Please call the parent's validator directly if you want to run both.
+
+        Args:
+            cls: The class this validator is attached to
+            val: The value to validate
+
+        Returns:
+            The validated value, possibly modified
+
+        """
         return val
 
     @staticmethod


### PR DESCRIPTION
Also adds a hook for custom AFTER validation, but maybe a "wrap" validator would be better. Then there is full flexibility for users to implement their own on subclasses of GatewayStructs.

Though I don't like that since we will have to pass the validator around for parent classes, and that's mucking around a bit too much with pydantic for my tastes (and not sure if it'll even consistently work)