### PR TITLE
Remove get_type_adapter, absorbed into csp since 0.8.0

### DIFF
--- a/csp_gateway/server/modules/web/websocket.py
+++ b/csp_gateway/server/modules/web/websocket.py
@@ -304,7 +304,7 @@ class MountWebSocketRoutes(GatewayModule):
 
                 # do conversion in its own little try/except to avoid ambiguity
                 try:
-                    type_adapter = channel_type.get_type_adapter()
+                    type_adapter = channel_type.type_adapter()
                     datum = [type_adapter.validate_python(obj) for obj in msg_data]
                 except Exception:
                     log.error("Error during websocket data conversion", exc_info=True)

--- a/csp_gateway/server/web/routes/shared.py
+++ b/csp_gateway/server/web/routes/shared.py
@@ -24,7 +24,7 @@ def prepare_response(
         #  Else return an empty json
         res = []
 
-    json_res_bytes = b"[" + b",".join(r.get_type_adapter().dump_json(r) for r in res) + b"]"
+    json_res_bytes = b"[" + b",".join(r.type_adapter().dump_json(r) for r in res) + b"]"
     json_res = json_res_bytes.decode()
     # Prepare and return response
     if wrap_in_response:

--- a/csp_gateway/tests/server/modules/io/test_json_converter.py
+++ b/csp_gateway/tests/server/modules/io/test_json_converter.py
@@ -503,7 +503,7 @@ def test_encode_decode(by_key):
         my_list_data=csp.const([MyStruct(foo=1.0), MyStruct(foo=2.0)]),
         by_key=by_key,
     )
-    raw_custom_struct = MyCustomStruct.get_type_adapter().validate_python(dict(mystery_val=["A", "A"]))  # must be A for serialization
+    raw_custom_struct = MyCustomStruct.type_adapter().validate_python(dict(mystery_val=["A", "A"]))  # must be A for serialization
     setter_mystery = SetMysteryClassModule(custom_struct=csp.const(raw_custom_struct))
     channels = [
         MyFatPipeChannels.my_channel,

--- a/csp_gateway/tests/server/web/test_shared.py
+++ b/csp_gateway/tests/server/web/test_shared.py
@@ -12,17 +12,17 @@ def test_prepare_response():
     response = prepare_response(res=data, is_list_model=False, is_dict_basket=False, wrap_in_response=True)
     assert isinstance(response, starlette.responses.Response)
     response = prepare_response(res=data, is_list_model=False, is_dict_basket=False, wrap_in_response=False)
-    assert json.loads(response) == [json.loads(data.get_type_adapter().dump_json(data))]
+    assert json.loads(response) == [json.loads(data.type_adapter().dump_json(data))]
 
 
 def test_prepare_response_list():
     data = ExampleData()
     response = prepare_response(res=[data], is_list_model=False, is_dict_basket=False, wrap_in_response=False)
-    assert json.loads(response) == [json.loads(data.get_type_adapter().dump_json(data))]
+    assert json.loads(response) == [json.loads(data.type_adapter().dump_json(data))]
     response = prepare_response(res=[data], is_list_model=True, is_dict_basket=False, wrap_in_response=False)
-    assert json.loads(response) == [json.loads(data.get_type_adapter().dump_json(data))]
+    assert json.loads(response) == [json.loads(data.type_adapter().dump_json(data))]
     response = prepare_response(res=(data,), is_list_model=True, is_dict_basket=False, wrap_in_response=False)
-    assert json.loads(response) == [json.loads(data.get_type_adapter().dump_json(data))]
+    assert json.loads(response) == [json.loads(data.type_adapter().dump_json(data))]
 
 
 def test_prepare_response_dict():
@@ -31,4 +31,4 @@ def test_prepare_response_dict():
         prepare_response(res={"foo": data}, is_list_model=False, is_dict_basket=False, wrap_in_response=False)
 
     response = prepare_response(res={"foo": data}, is_list_model=False, is_dict_basket=True, wrap_in_response=False)
-    assert json.loads(response) == [json.loads(data.get_type_adapter().dump_json(data))]
+    assert json.loads(response) == [json.loads(data.type_adapter().dump_json(data))]

--- a/csp_gateway/utils/struct/base.py
+++ b/csp_gateway/utils/struct/base.py
@@ -10,7 +10,7 @@ from csp.impl.types.container_type_normalizer import ContainerTypeNormalizer
 from csp.impl.types.typing_utils import CspTypingUtils
 from numpy import ndarray
 from pyarrow import Array, Schema, Table
-from pydantic import BaseModel, TypeAdapter, create_model, model_validator
+from pydantic import BaseModel, create_model, model_validator
 from pydantic.fields import FieldInfo
 
 from ..id_generator import get_counter
@@ -274,7 +274,6 @@ class PydanticizedCspStruct(StructMeta):
         # But expose this lookup as a readonly mapping proxy
         cls.lookup = MappingProxyType(cls._internal_mapping).get
         cls._include_in_lookup = True
-        cls._type_adapter = TypeAdapter(cls)
 
     def omit_from_lookup(cls, omit=True):
         cls._include_in_lookup = not omit
@@ -317,10 +316,6 @@ class GatewayStruct(PerspectiveUtilityMixin, Struct, metaclass=PydanticizedCspSt
 
         # and defer to normal csp.struct construction
         super().__init__(**kwargs)
-
-    @classmethod
-    def get_type_adapter(cls) -> TypeAdapter:
-        return cls._type_adapter
 
     @classmethod
     def generate_id(cls) -> str:


### PR DESCRIPTION
The type adapter can now be accessed on a base csp Struct, we can avoid needing to add it here for GatewayStruct's in particular.