### PR TITLE
Disable OpsGenie heartbeat on gateway stop

### DIFF
--- a/csp_gateway/server/modules/logging/opsgenie.py
+++ b/csp_gateway/server/modules/logging/opsgenie.py
@@ -178,6 +178,17 @@ class PublishOpsGenie(GatewayModule):
             # init heartbeat object in synchronous mode
             self._init_heartbeat(heartbeat_api=s_heartbeat_api)
 
+        with csp.stop():
+            try:
+                s_heartbeat_api.disable_heartbeat(
+                    self.ops_heartbeat_name,
+                    async_req=False,
+                    _request_timeout=self.ops_sync_delay_sec,
+                )
+                log.info("Disabled heartbeat '%s' on shutdown", self.ops_heartbeat_name)
+            except Exception as e:
+                log.error("Failed to disable heartbeat '%s' on shutdown: %s", self.ops_heartbeat_name, e)
+
         if csp.ticked(data):
             for metric in data:
                 log.trace("Received metric %s", metric.metric)

--- a/csp_gateway/tests/server/modules/logging/test_opsgenie.py
+++ b/csp_gateway/tests/server/modules/logging/test_opsgenie.py
@@ -117,11 +117,13 @@ class EventTestModule(GatewayModule):
 @mock.patch("opsgenie_sdk.HeartbeatApi.get_heartbeat")
 @mock.patch("opsgenie_sdk.HeartbeatApi.create_heartbeat")
 @mock.patch("opsgenie_sdk.HeartbeatApi.update_heartbeat")
+@mock.patch("opsgenie_sdk.HeartbeatApi.disable_heartbeat")
 @mock.patch.object(opsgenie_sdk.HeartbeatApi, "ping")
 @mock.patch("logging.Logger.trace")
 def test_opsgenie(
     mock_trace,
     mock_ping,
+    mock_disable_heartbeat,
     mock_update_heartbeat,
     mock_create_heartbeat,
     mock_get_heartbeat,
@@ -235,3 +237,64 @@ def test_opsgenie(
     assert update_heartbeat_kwargs["update_heartbeat_payload"].to_dict() == expected_payload.to_dict()
 
     assert mock_create_heartbeat.call_count == 0
+
+    # heartbeat should be disabled on shutdown
+    assert mock_disable_heartbeat.call_count == 1
+    disable_args = mock_disable_heartbeat.call_args_list[0].args
+    disable_kwargs = mock_disable_heartbeat.call_args_list[0].kwargs
+    assert disable_args == ("test_heartbeat",)
+    assert disable_kwargs == {"async_req": False, "_request_timeout": 5.0}
+
+
+@mock.patch("opsgenie_sdk.CreateHeartbeatPayload")
+@mock.patch("opsgenie_sdk.HeartbeatApi.get_heartbeat")
+@mock.patch("opsgenie_sdk.HeartbeatApi.create_heartbeat")
+@mock.patch("opsgenie_sdk.HeartbeatApi.update_heartbeat")
+@mock.patch("opsgenie_sdk.HeartbeatApi.disable_heartbeat")
+@mock.patch.object(opsgenie_sdk.HeartbeatApi, "ping")
+@mock.patch("logging.Logger.error")
+def test_opsgenie_disable_heartbeat_failure_is_logged(
+    mock_error,
+    mock_ping,
+    mock_disable_heartbeat,
+    mock_update_heartbeat,
+    mock_create_heartbeat,
+    mock_get_heartbeat,
+    mock_create_heartbeat_payload,
+):
+    """disable_heartbeat exceptions on shutdown should be logged but not raised."""
+    mock_ping_response = Mock()
+    mock_ping_response.ready.return_value = True
+    mock_ping_response.get.return_value = Mock(result="PONG - Heartbeat received")
+    mock_ping.return_value = mock_ping_response
+
+    mock_disable_heartbeat.side_effect = RuntimeError("opsgenie unreachable")
+
+    h = GatewayTestHarness(test_channels=["metric"])
+    gateway = Gateway(
+        modules=[
+            h,
+            EventTestModule(),
+            PublishOpsGenie(
+                ops_api_key="foo123",
+                ops_heartbeat_name="test_heartbeat",
+                ops_tags={"user": "test0123", "trading_area": "ABCD"},
+                ops_async_delay_sec=3.0,
+                metrics_channel="metric",
+            ),
+        ],
+        channels=EventTestChannels(),
+    )
+    h.delay(timedelta(seconds=1))
+    csp.run(
+        gateway.graph,
+        starttime=datetime.now(timezone.utc),
+        endtime=timedelta(seconds=2),
+    )
+
+    assert mock_disable_heartbeat.call_count == 1
+    mock_error.assert_any_call(
+        "Failed to disable heartbeat '%s' on shutdown: %s",
+        "test_heartbeat",
+        mock_disable_heartbeat.side_effect,
+    )


### PR DESCRIPTION
## Summary
- Disables the OpsGenie heartbeat when the gateway shuts down via `csp.stop()`, so that heartbeat alerts fire promptly after a gateway goes offline rather than waiting for the heartbeat to time out.
- Failures in the disable call are logged but do not propagate, keeping shutdown safe.

## Test plan
- [x] Existing `test_opsgenie` updated to assert `disable_heartbeat` is called on shutdown with correct args
- [x] New `test_opsgenie_disable_heartbeat_failure_is_logged` verifies exceptions are caught and logged