### PR TITLE
rework table registry with backwards compatibility, strip theme from js download, bump psp js

### DIFF
--- a/csp_gateway/server/config/gateway/omnibus.yaml
+++ b/csp_gateway/server/config/gateway/omnibus.yaml
@@ -22,12 +22,19 @@ modules:
     perspective_field: "perspective"
     layouts:
       Server Defined Layout: '{"sizes":[1],"detail":{"main":{"type":"split-area","orientation":"vertical","children":[{"type":"split-area","orientation":"horizontal","children":[{"type":"tab-area","widgets":["EXAMPLE_LIST_GENERATED_4"],"currentIndex":0},{"type":"tab-area","widgets":["PERSPECTIVE_GENERATED_ID_1"],"currentIndex":0}],"sizes":[0.3,0.7]},{"type":"split-area","orientation":"horizontal","children":[{"type":"tab-area","widgets":["EXAMPLE_GENERATED_3"],"currentIndex":0},{"type":"tab-area","widgets":["PERSPECTIVE_GENERATED_ID_0"],"currentIndex":0}],"sizes":[0.3,0.7]}],"sizes":[0.5,0.5]}},"viewers":{"EXAMPLE_LIST_GENERATED_4":{"version":"3.3.4","plugin":"Datagrid","plugin_config":{"columns":{},"edit_mode":"READ_ONLY","scroll_lock":false},"columns_config":{},"title":"example_list","group_by":[],"split_by":[],"columns":["timestamp","x","y","data","mapping","dt","d","internal_csp_struct.z"],"filter":[],"sort":[["timestamp","desc"]],"expressions":{},"aggregates":{},"table":"example_list","settings":false},"PERSPECTIVE_GENERATED_ID_1":{"version":"3.3.4","plugin":"X Bar","plugin_config":{},"columns_config":{},"title":"example_list (*)","group_by":["x"],"split_by":[],"columns":["y"],"filter":[],"sort":[["x","asc"]],"expressions":{},"aggregates":{"y":"median"},"table":"example_list","settings":false},"EXAMPLE_GENERATED_3":{"version":"3.3.4","plugin":"Datagrid","plugin_config":{"columns":{},"edit_mode":"READ_ONLY","scroll_lock":false},"columns_config":{},"title":"example","group_by":[],"split_by":[],"columns":["timestamp","x","y","data","mapping","dt","d","internal_csp_struct.z"],"filter":[],"sort":[["timestamp","desc"]],"expressions":{},"aggregates":{},"table":"example","settings":false},"PERSPECTIVE_GENERATED_ID_0":{"version":"3.3.4","plugin":"Treemap","plugin_config":{},"columns_config":{},"title":"example (*)","group_by":["x"],"split_by":[],"columns":["y","x",null],"filter":[],"sort":[["timestamp","desc"]],"expressions":{},"aggregates":{},"table":"example","settings":false}}}'
-    limits:
-      str_basket: 20
+    tables:
+      # Primary table with multi-index
+      example:
+        index: ["x", "y"]
+      # Additional table: same channel, no index (full append-only history)
+      example_full_history:
+        channel: example
+        limit: 100
+      # Primary table with limit
+      str_basket:
+        limit: 20
     architectures:
       basket: server
-    indexes:
-      example: ["x", "y"]
     server_views:
       server_view:
         table: example

--- a/csp_gateway/server/modules/web/perspective.py
+++ b/csp_gateway/server/modules/web/perspective.py
@@ -22,7 +22,7 @@ from csp import ts
 from fastapi import APIRouter, WebSocket
 from perspective import Client, Server, Table
 from perspective.handlers.starlette import PerspectiveStarletteHandler
-from pydantic import Field, PrivateAttr, field_validator
+from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 from starlette.websockets import WebSocketDisconnect
 from typing_extensions import TypeAliasType
 
@@ -33,6 +33,7 @@ from csp_gateway.utils import PickleableQueue, get_args, get_origin, get_thread
 __all__ = (
     "psp_schema_to_arrow_schema",
     "create_pyarrow_table",
+    "TableConfig",
     "MountPerspectiveTables",
 )
 
@@ -141,23 +142,74 @@ ViewConfig = Dict[
 ]
 
 
+class TableConfig(BaseModel):
+    """Configuration for a perspective table. When channel is omitted, defaults to using the table name as the channel."""
+
+    channel: Optional[str] = Field(None, description="The source channel name. Defaults to the table name if omitted.")
+    limit: Optional[int] = Field(None, description="Row limit for this table.")
+    index: Optional[Union[str, List[str]]] = Field(None, description="Index field(s) for this table.")
+    architecture: Literal["server", "client-server"] = Field("client-server", description="Perspective data architecture for this table.")
+    excluded_columns: Optional[ExcludedColumns] = Field(None, description="Columns to exclude from the schema.")
+
+
+# Backwards compat alias
+AdditionalTableConfig = TableConfig
+
+
+def _is_channel_selection_input(v) -> bool:
+    """Detect whether a raw input value looks like a ChannelSelection (old-style tables field)."""
+    if v is None or isinstance(v, list):
+        return True
+    if isinstance(v, ChannelSelection):
+        return True
+    if isinstance(v, dict):
+        keys = set(v.keys())
+        # Empty dict is ambiguous — treat as empty TableConfig dict (new-style)
+        if len(keys) == 0:
+            return False
+        if keys <= {"include", "exclude"}:
+            # Verify values aren't TableConfig-like dicts (handles edge case of channel named "include"/"exclude")
+            for val in v.values():
+                if isinstance(val, (dict, TableConfig)):
+                    return False
+            return True
+    return False
+
+
 class MountPerspectiveTables(GatewayModule):
     requires: Optional[ChannelSelection] = []
 
-    tables: ChannelSelection = Field(default_factory=ChannelSelection)
+    tables: Dict[str, TableConfig] = Field(
+        default={},
+        description=(
+            "Dictionary mapping table name to a TableConfig. Each entry configures a perspective table. "
+            "If 'channel' is omitted in the config, the table name is used as the channel name. "
+            "If 'channel' is set to a different name, an additional table is created mirroring that channel's data. "
+            "Tables entries whose channel matches their name override per-table settings from legacy fields "
+            "(limits, indexes, etc.). For backwards compatibility, this field also accepts a ChannelSelection "
+            "(list or dict with include/exclude keys) which will be moved to 'channel_selection'."
+        ),
+    )
+    channel_selection: ChannelSelection = Field(
+        default_factory=ChannelSelection,
+        description="Controls which channels are auto-discovered as perspective tables. "
+        "Channels not explicitly listed in 'tables' will use defaults. "
+        "This is the successor to the old 'tables' field when it was a ChannelSelection.",
+    )
     _unused_tables: Optional[List[str]] = PrivateAttr(default_factory=list)
 
     server_views: Optional[Dict[str, ViewConfig]] = Field(
         default_factory=dict, description="Optional dict mapping new table name to a dict with table and view information"
     )
 
+    # Legacy per-table config fields (still functional; tables entries take precedence)
     limits: Dict[str, int] = Field(
         description="Dict mapping table name to [perspective limit](https://perspective-dev.github.io/guide/explanation/table/options.html)",
         default={},
     )
     default_limit: Optional[int] = Field(None, description="Default limit for all tables, i.e. 1000")
     indexes: Dict[str, Optional[Union[str, List[str]]]] = Field(
-        description="Dict mapping table name to [perspective index](https://perspective-dev.github.io/guide/explanation/table/options.html). . If a multi-index is provided, will create a new computed index field.",
+        description="Dict mapping table name to [perspective index](https://perspective-dev.github.io/guide/explanation/table/options.html). If a multi-index is provided, will create a new computed index field.",
         default={},
     )
     default_index: Optional[Union[str, List[str]]] = Field(
@@ -170,6 +222,15 @@ class MountPerspectiveTables(GatewayModule):
     default_architecture: Literal["server", "client-server"] = Field(
         "client-server",
         description="Default architecture for all tables, i.e. 'client-server'",
+    )
+    excluded_table_columns: Dict[str, ExcludedColumns] = Field(
+        default={},
+        description=(
+            "Dictionary from table name to columns (which are attributes on a GatewayStruct) to exclude from perspective. "
+            "The columns to exclude can be specified as either be a set of column names or as a dictionary. If specified "
+            "as a dictionary, the dictionary is a mapping from attribute name to sub-attributes to exclude. This is defined "
+            "recursively so it can be used to exclude fields that are structs of structs."
+        ),
     )
 
     layouts: Dict[str, str] = Field(default={})
@@ -189,15 +250,28 @@ class MountPerspectiveTables(GatewayModule):
         description="Optional field on the channels which has a dictionary of layouts to use, "
         "such that it can also be used by other GatewayModules with custom table preparation logic.",
     )
-    excluded_table_columns: Dict[str, ExcludedColumns] = Field(
-        default={},
-        description=(
-            "Dictionary from table name to columns (which are attributes on a GatewayStruct) to exclude from perspective. "
-            "The columns to exclude can be specified as either be a set of column names or as a dictionary. If specified "
-            "as a dictionary, the dictionary is a mapping from attribute name to sub-attributes to exclude. This is defined "
-            "recursively so it can be used to exclude fields that are structs of structs."
-        ),
-    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_tables_input(cls, data):
+        if not isinstance(data, dict):
+            return data
+
+        tables_input = data.get("tables")
+        if _is_channel_selection_input(tables_input):
+            # Old style: `tables` was a ChannelSelection — move to channel_selection
+            # Only do this if channel_selection is not already explicitly provided
+            if tables_input is not None and "channel_selection" not in data:
+                data["channel_selection"] = tables_input
+            data.pop("tables", None)
+
+        # Merge deprecated additional_tables into tables
+        additional = data.pop("additional_tables", None)
+        if additional:
+            tables = data.setdefault("tables", {})
+            tables.update(additional)
+
+        return data
 
     _route: str = "/perspective"
     _server: Server = PrivateAttr(default=None)
@@ -224,11 +298,37 @@ class MountPerspectiveTables(GatewayModule):
                 raise ValueError(f"View config for {new_table_name} must specify at least one view operation in addition to the base 'table'.")
         return v
 
+    def _get_effective_config(self, table_name: str) -> TableConfig:
+        """Get effective config for a table, merging tables dict entry with legacy fields and defaults."""
+        config = self.tables.get(table_name)
+        if config:
+            return TableConfig(
+                channel=config.channel,
+                limit=config.limit if config.limit is not None else self.limits.get(table_name, self.default_limit),
+                index=config.index if config.index is not None else self.indexes.get(table_name, self.default_index),
+                architecture=config.architecture or self.architectures.get(table_name, self.default_architecture),
+                excluded_columns=config.excluded_columns if config.excluded_columns is not None else self.excluded_table_columns.get(table_name),
+            )
+        return TableConfig(
+            limit=self.limits.get(table_name, self.default_limit),
+            index=self.indexes.get(table_name, self.default_index),
+            architecture=self.architectures.get(table_name, self.default_architecture),
+            excluded_columns=self.excluded_table_columns.get(table_name),
+        )
+
     def _connect_all_tables(self, channels: GatewayChannels) -> None:
-        selected_tables = set(self.tables.select_from(channels)) | set(_["table"] for _ in self.server_views.values())
-        for field in selected_tables:
+        # Determine primary channels from channel_selection + server_views + tables entries without explicit channel
+        selected_channels = set(self.channel_selection.select_from(channels)) | set(_["table"] for _ in self.server_views.values())
+        for table_name, config in self.tables.items():
+            channel = config.channel or table_name
+            if channel == table_name:
+                selected_channels.add(table_name)
+
+        # Register primary tables (table_name == channel_name)
+        for field in selected_channels:
+            config = self._get_effective_config(field)
             edge = channels.get_channel(field)
-            excluded_columns = self.excluded_table_columns.get(field, None)
+            excluded_columns = config.excluded_columns
             if isinstance(edge, dict):
                 if not edge:
                     raise ValueError(f"No keys defined for dict basket channel {field}.")
@@ -244,8 +344,8 @@ class MountPerspectiveTables(GatewayModule):
                 self.add_table(
                     field,
                     schema,
-                    limit=self.limits.get(field, self.default_limit),
-                    index=self.indexes.get(field, self.default_index),
+                    limit=config.limit,
+                    index=config.index,
                 )
 
                 if hasattr(subfield, "name"):
@@ -265,8 +365,8 @@ class MountPerspectiveTables(GatewayModule):
                 self.add_table(
                     field,
                     schema,
-                    limit=self.limits.get(field, self.default_limit),
-                    index=self.indexes.get(field, self.default_index),
+                    limit=config.limit,
+                    index=config.index,
                 )
                 self.push_to_perspective(
                     edge,
@@ -285,6 +385,64 @@ class MountPerspectiveTables(GatewayModule):
             base_table = self._client.open_table(view_config.pop("table"))
             view = base_table.view(**view_config)
             self._table_insts[new_table_name] = self._client.table(view, name=new_table_name)
+
+        # Register additional tables (tables entries where channel differs from table_name)
+        for table_name, table_config in self.tables.items():
+            channel = table_config.channel or table_name
+            if channel == table_name:
+                continue  # Already handled as a primary table above
+
+            if channel not in self._schema_insts:
+                raise ValueError(
+                    f"Table '{table_name}' references channel '{channel}' which is not a registered table. "
+                    f"Ensure '{channel}' is included in the channel selection or as a primary table."
+                )
+            config = self._get_effective_config(table_name)
+            excluded_columns = config.excluded_columns
+            if excluded_columns is not None:
+                # Recompute schema with different exclusions
+                edge = channels.get_channel(channel)
+                if isinstance(edge, dict):
+                    a_subfield = list(edge.keys())[0]
+                    ts_type = channels.get_channel(channel, a_subfield).tstype.typ
+                else:
+                    ts_type = edge.tstype.typ
+                    if get_origin(ts_type) is list:
+                        ts_type = get_args(ts_type)[0]
+                schema = ts_type.psp_schema(excluded_columns)
+            else:
+                schema = self._schema_insts[channel].copy()
+
+            self.add_table(
+                table_name,
+                schema,
+                limit=config.limit,
+                index=config.index,
+            )
+            self._schema_insts[table_name] = schema
+            self._arrow_schema_insts[table_name] = psp_schema_to_arrow_schema(schema)
+            self._arrow_schema_date_conversions[table_name] = set()
+            for k, v in schema.items():
+                if v is date:
+                    self._arrow_schema_date_conversions[table_name].add(k)
+
+            # Wire up data flow: push same channel data to the additional table
+            edge = channels.get_channel(channel)
+            if isinstance(edge, dict):
+                to_flatten = []
+                for subfield in edge.keys():
+                    to_flatten.append(channels.get_channel(channel, subfield))
+                if hasattr(subfield, "name"):
+                    self.push_to_perspective(csp.flatten(to_flatten), table_name, subfield.name)
+                else:
+                    self.push_to_perspective(csp.flatten(to_flatten), table_name, subfield)
+            else:
+                ts_type = channels.get_channel(channel).tstype.typ
+                if get_origin(ts_type) is list:
+                    edge = csp.unroll(channels.get_channel(channel))
+                else:
+                    edge = channels.get_channel(channel)
+                self.push_to_perspective(edge, table_name)
 
     def get_schema_from_field(self, channels: GatewayChannels, field: str):
         edge = channels.get_channel(field)
@@ -451,11 +609,15 @@ class MountPerspectiveTables(GatewayModule):
             indexes, and architecture.
             """
             return {
-                "limits": self.limits,
+                "limits": {**self.limits, **{k: v.limit for k, v in self.tables.items() if v.limit is not None}},
                 "default_limit": self.default_limit,
-                "indexes": {**self.indexes, **{k: v[0] for k, v in self._computed_indexes.items()}},
+                "indexes": {
+                    **self.indexes,
+                    **{k: v.index for k, v in self.tables.items() if v.index is not None},
+                    **{k: v[0] for k, v in self._computed_indexes.items()},
+                },
                 "default_index": self.default_index,
-                "architectures": self.architectures,
+                "architectures": {**self.architectures, **{k: v.architecture for k, v in self.tables.items()}},
                 "default_architecture": self.default_architecture,
                 "layouts": self.layouts,
                 "default_layout": self.default_layout,

--- a/csp_gateway/tests/server/modules/web/test_perspective.py
+++ b/csp_gateway/tests/server/modules/web/test_perspective.py
@@ -566,3 +566,195 @@ def test_exclude_unused_tables():
 
     # Assert that tables were pruned
     assert sorted(psp_module._unused_tables) == sorted(["b", "d", "f"])
+
+
+def test_additional_tables():
+    """Test that additional_tables creates duplicate tables from the same channel with different config."""
+    from csp_gateway.server.modules.web.perspective import AdditionalTableConfig
+
+    module = MountPerspectiveTables(
+        tables={"include": ["test_channel", "limit_channel"]},
+        indexes={"test_channel": "id"},
+        limits={"limit_channel": 5},
+        additional_tables={
+            "test_channel_no_index": AdditionalTableConfig(
+                channel="test_channel",
+                # no index, no limit - raw append
+            ),
+            "test_channel_limited": AdditionalTableConfig(
+                channel="test_channel",
+                limit=3,
+            ),
+            "limit_channel_full": AdditionalTableConfig(
+                channel="limit_channel",
+                # no limit override - gets all rows
+            ),
+        },
+        update_interval=timedelta(seconds=0.5),
+    )
+
+    h = GatewayTestHarness(
+        test_channels=[GWC.test_channel, GWC.limit_channel],
+    )
+
+    now = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
+    o = MyTestStruct(sub=MyTestSubStruct(y=[1], timestamp=now), timestamp=now)
+
+    for _ in range(10):
+        h.send(GWC.test_channel, o)
+        h.send(GWC.limit_channel, o)
+    h.assert_ticked(GWC.test_channel, 10)
+    h.assert_ticked(GWC.limit_channel, 10)
+
+    h.delay(2 * module.update_interval)  # So that the buffer is flushed
+    channels = GWC()
+    gateway = Gateway(modules=[h, module], channels=channels)
+    csp.run(gateway.graph, starttime=datetime(2023, 1, 1), endtime=timedelta(5))
+
+    psp = module._server
+
+    # All tables should be registered
+    table_names = sorted(psp.new_local_client().get_hosted_table_names())
+    assert "test_channel" in table_names
+    assert "test_channel_no_index" in table_names
+    assert "test_channel_limited" in table_names
+    assert "limit_channel" in table_names
+    assert "limit_channel_full" in table_names
+
+    def table_len(name):
+        return len(psp.new_local_client().open_table(name).view().to_json())
+
+    # test_channel has index="id", so all rows collapse to 1
+    assert table_len("test_channel") == 1
+    # test_channel_no_index has no index, all 10 rows kept
+    assert table_len("test_channel_no_index") == 10
+    # test_channel_limited has limit=3, so at most 3 rows
+    assert table_len("test_channel_limited") == 3
+
+    # limit_channel has limit=5
+    assert table_len("limit_channel") == 5
+    # limit_channel_full has no limit, all 10 rows
+    assert table_len("limit_channel_full") == 10
+
+
+def test_additional_tables_with_dict_channel():
+    """Test that additional_tables works with dict basket channels."""
+    from csp_gateway.server.modules.web.perspective import AdditionalTableConfig
+
+    module = MountPerspectiveTables(
+        tables={"include": ["dict_channel"]},
+        indexes={"dict_channel": "id"},
+        additional_tables={
+            "dict_channel_no_index": AdditionalTableConfig(
+                channel="dict_channel",
+                # no index - keeps all rows
+            ),
+        },
+        update_interval=timedelta(seconds=0.5),
+    )
+
+    h = GatewayTestHarness(
+        test_channels=[GWC.dict_channel],
+        test_dynamic_keys={"dict_channel": ["test_key"]},
+    )
+
+    now = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
+    o = MyTestStruct(sub=MyTestSubStruct(y=[1], timestamp=now), timestamp=now)
+
+    for _ in range(5):
+        h.send(GWC.dict_channel, {"test_key": o})
+    h.assert_ticked((GWC.dict_channel, "test_key"), 5)
+
+    h.delay(2 * module.update_interval)
+    channels = GWC()
+    gateway = Gateway(modules=[h, module], channels=channels)
+    csp.run(gateway.graph, starttime=datetime(2023, 1, 1), endtime=timedelta(5))
+
+    psp = module._server
+
+    def table_len(name):
+        return len(psp.new_local_client().open_table(name).view().to_json())
+
+    # dict_channel has index="id", collapses to 1 row
+    assert table_len("dict_channel") == 1
+    # dict_channel_no_index has no index, all 5 rows kept
+    assert table_len("dict_channel_no_index") == 5
+
+
+def test_additional_tables_invalid_channel():
+    """Test that referencing a non-existent channel raises an error."""
+    from csp_gateway.server.modules.web.perspective import AdditionalTableConfig
+
+    module = MountPerspectiveTables(
+        tables={"include": ["test_channel"]},
+        additional_tables={
+            "bogus_table": AdditionalTableConfig(
+                channel="nonexistent_channel",
+            ),
+        },
+        update_interval=timedelta(seconds=0.5),
+    )
+
+    h = GatewayTestHarness(
+        test_channels=[GWC.test_channel],
+    )
+
+    now = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
+    o = MyTestStruct(sub=MyTestSubStruct(y=[1], timestamp=now), timestamp=now)
+    h.send(GWC.test_channel, o)
+
+    channels = GWC()
+    gateway = Gateway(modules=[h, module], channels=channels)
+    with pytest.raises(ValueError, match="references channel 'nonexistent_channel'"):
+        csp.run(gateway.graph, starttime=datetime(2023, 1, 1), endtime=timedelta(5))
+
+
+def test_tables_unified_api():
+    """Test the new unified tables API where everything is configured via tables dict."""
+    from csp_gateway.server.modules.web.perspective import TableConfig
+
+    module = MountPerspectiveTables(
+        tables={
+            # Primary table with config override (channel == table_name when omitted)
+            "test_channel": TableConfig(index="id"),
+            # Primary table with limit
+            "limit_channel": TableConfig(limit=5),
+            # Additional table: same channel, different config
+            "test_channel_no_index": TableConfig(channel="test_channel"),
+            "test_channel_limited": TableConfig(channel="test_channel", limit=3),
+        },
+        channel_selection={"exclude": ["dict_channel", "dict_enum_channel", "index_channel", "exclude_channel"]},
+        update_interval=timedelta(seconds=0.5),
+    )
+
+    h = GatewayTestHarness(
+        test_channels=[GWC.test_channel, GWC.limit_channel],
+    )
+
+    now = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
+    o = MyTestStruct(sub=MyTestSubStruct(y=[1], timestamp=now), timestamp=now)
+
+    for _ in range(10):
+        h.send(GWC.test_channel, o)
+        h.send(GWC.limit_channel, o)
+    h.assert_ticked(GWC.test_channel, 10)
+    h.assert_ticked(GWC.limit_channel, 10)
+
+    h.delay(2 * module.update_interval)
+    channels = GWC()
+    gateway = Gateway(modules=[h, module], channels=channels)
+    csp.run(gateway.graph, starttime=datetime(2023, 1, 1), endtime=timedelta(5))
+
+    psp = module._server
+
+    def table_len(name):
+        return len(psp.new_local_client().open_table(name).view().to_json())
+
+    # test_channel has index="id" via TableConfig, collapses to 1
+    assert table_len("test_channel") == 1
+    # test_channel_no_index has no index, keeps all 10
+    assert table_len("test_channel_no_index") == 10
+    # test_channel_limited has limit=3
+    assert table_len("test_channel_limited") == 3
+    # limit_channel has limit=5
+    assert table_len("limit_channel") == 5

--- a/js/package.json
+++ b/js/package.json
@@ -21,13 +21,13 @@
     "react-modern-drawer": "^1.4.0"
   },
   "devDependencies": {
-    "@perspective-dev/client": "~4.5.0",
-    "@perspective-dev/react": "~4.5.0",
-    "@perspective-dev/server": "~4.5.0",
-    "@perspective-dev/viewer": "~4.5.0",
-    "@perspective-dev/viewer-d3fc": "~4.4.1",
-    "@perspective-dev/viewer-datagrid": "~4.5.0",
-    "@perspective-dev/workspace": "~4.5.0",
+    "@perspective-dev/client": "~4.5.1",
+    "@perspective-dev/react": "~4.5.1",
+    "@perspective-dev/server": "~4.5.1",
+    "@perspective-dev/viewer": "~4.5.1",
+    "@perspective-dev/viewer-charts": "~4.5.1",
+    "@perspective-dev/viewer-datagrid": "~4.5.1",
+    "@perspective-dev/workspace": "~4.5.1",
     "cpy": "^13.2.2",
     "esbuild": "^0.28.0",
     "lightningcss": "^1.29.3",
@@ -37,13 +37,13 @@
     "react-dom": "19.2.6"
   },
   "peerDependencies": {
-    "@perspective-dev/client": "~4.4.1",
-    "@perspective-dev/react": "~4.4.1",
-    "@perspective-dev/server": "~4.4.1",
-    "@perspective-dev/viewer": "~4.4.1",
-    "@perspective-dev/viewer-d3fc": "~4.4.1",
-    "@perspective-dev/viewer-datagrid": "~4.4.1",
-    "@perspective-dev/workspace": "~4.4.1",
+    "@perspective-dev/client": "~4.5.1",
+    "@perspective-dev/react": "~4.5.1",
+    "@perspective-dev/server": "~4.5.1",
+    "@perspective-dev/viewer": "~4.5.1",
+    "@perspective-dev/viewer-charts": "~4.5.1",
+    "@perspective-dev/viewer-datagrid": "~4.5.1",
+    "@perspective-dev/workspace": "~4.5.1",
     "react": "19.2.6",
     "react-dom": "19.2.6"
   }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -20,26 +20,26 @@ importers:
         version: 1.4.0(react@19.2.6)
     devDependencies:
       '@perspective-dev/client':
-        specifier: ~4.5.0
-        version: 4.5.0
+        specifier: ~4.5.1
+        version: 4.5.1
       '@perspective-dev/react':
-        specifier: ~4.5.0
-        version: 4.5.0
+        specifier: ~4.5.1
+        version: 4.5.1
       '@perspective-dev/server':
-        specifier: ~4.5.0
-        version: 4.5.0
+        specifier: ~4.5.1
+        version: 4.5.1
       '@perspective-dev/viewer':
-        specifier: ~4.5.0
-        version: 4.5.0
-      '@perspective-dev/viewer-d3fc':
-        specifier: ~4.4.1
-        version: 4.4.1(d3-brush@3.0.0)(d3-dispatch@3.0.1)(d3-fetch@3.0.1)(d3-path@3.1.0)(d3-random@3.0.1)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-shape@3.2.0)(d3-time@3.1.0)(d3-zoom@3.0.0)
+        specifier: ~4.5.1
+        version: 4.5.1
+      '@perspective-dev/viewer-charts':
+        specifier: ~4.5.1
+        version: 4.5.1
       '@perspective-dev/viewer-datagrid':
-        specifier: ~4.5.0
-        version: 4.5.0
+        specifier: ~4.5.1
+        version: 4.5.1
       '@perspective-dev/workspace':
-        specifier: ~4.5.0
-        version: 4.5.0
+        specifier: ~4.5.1
+        version: 4.5.1
       cpy:
         specifier: ^13.2.2
         version: 13.2.2
@@ -63,119 +63,6 @@ importers:
         version: 19.2.6(react@19.2.6)
 
 packages:
-
-  '@d3fc/d3fc-annotation@3.0.16':
-    resolution: {integrity: sha512-4tA7RHLUbj/i3KqWRqCVDOHi435qBRXbAFrAajVYM2juNzFdX5RCoF3opyXKOFncs339caxgeySGStTVfulO9w==}
-    peerDependencies:
-      d3-scale: '*'
-      d3-selection: '*'
-
-  '@d3fc/d3fc-axis@3.0.7':
-    resolution: {integrity: sha512-S4pILxkQUkD7WQmimWxIEHfXUYEonlXWuWvMP6iq3KXL3d+cj4flvwNqLYZvSVaQDdK990cKkjrK/ZAKnReGlg==}
-    peerDependencies:
-      d3-scale: '*'
-      d3-selection: '*'
-      d3-shape: '*'
-
-  '@d3fc/d3fc-brush@3.0.3':
-    resolution: {integrity: sha512-fc1XBuNWl6DQVFSnBdauI/WNRvtNaeUWwDiLEIMY+v0VlrmGOgWEGCB5otVepGZiL56cjgRtHdwYBdKCvgGBSg==}
-    peerDependencies:
-      d3-brush: '*'
-      d3-dispatch: '*'
-      d3-scale: '*'
-      d3-selection: '*'
-
-  '@d3fc/d3fc-chart@5.1.9':
-    resolution: {integrity: sha512-xFO9lDUi2wAkjfyWlVZuFwSWEgnk0WOEagR2R9KzQ+uxeg3oZOPzwE+AZbpALyQbjjQ2uIxcOk56xnmnnayk3w==}
-    peerDependencies:
-      d3-scale: '*'
-      d3-selection: '*'
-
-  '@d3fc/d3fc-data-join@6.0.3':
-    resolution: {integrity: sha512-fd1D2Cl4YGjzl3gBhcrvTl/VxaSncY0ZcokWsN8ahtmk9DZK4DnAgHGrdecnXVLkOx+ANDcqxqscYz6MWXLbcA==}
-    peerDependencies:
-      d3-selection: '*'
-
-  '@d3fc/d3fc-discontinuous-scale@4.1.1':
-    resolution: {integrity: sha512-cyhtq4XPtK8RCSBtzctRAl4RkDyYJqJY0SJpi3QcfJz/OX9iB6At7UjITO7tAmJ7RUHb/xZvAVpJU8BM5gaQqg==}
-    peerDependencies:
-      d3-scale: '*'
-      d3-time: '*'
-
-  '@d3fc/d3fc-element@6.2.0':
-    resolution: {integrity: sha512-AvdZ3V4mVxF9dGYLiDCoqr3GhrFOUQEc1FcP20QEhQ3fJ3qYRwx7/uhL7G/L2xbe6k4delPgnLOvtoaDenhpZw==}
-
-  '@d3fc/d3fc-extent@4.0.2':
-    resolution: {integrity: sha512-m7w7Dof6KAIDtgzIsTcprWTEoiqExJGsGoQbb97bF+EwIkuEZWRUl1jkoeNL00efpX1o6zSdqSr6lojoR0aI/g==}
-    peerDependencies:
-      d3-array: '*'
-
-  '@d3fc/d3fc-financial-feed@7.1.0':
-    resolution: {integrity: sha512-K8jktdRJQAiJepglErsuY2ZMKsm0YFWTeuhYnTFb8rWmyhwoPeem9QW+e6xBTiAvbElJm4yTrkal09KmO2cLlQ==}
-    peerDependencies:
-      d3-fetch: '*'
-
-  '@d3fc/d3fc-group@3.0.1':
-    resolution: {integrity: sha512-GBUR6a4hkqfSo77iaFS4qPMS5tupH8hmJ8eniiD45GFmWQs69+Dlf8Uhx+GCCvQkE+px6rQyZWVCJKBq6gkz2Q==}
-
-  '@d3fc/d3fc-label-layout@7.0.4':
-    resolution: {integrity: sha512-4CCyOx6uQA/Eq1VHnNy9dpI5QE2sDd1EP4W0Nw2rwnhFtlQqv37V38b9y5zT4YcdFrEgJqSB81fXIt3ZK1yxSg==}
-    peerDependencies:
-      d3-array: '*'
-      d3-scale: '*'
-      d3-selection: '*'
-
-  '@d3fc/d3fc-pointer@3.0.3':
-    resolution: {integrity: sha512-hXY7LqliDEJBH/do4YZusdLoikLYlWoN7efPC7YKYJ8igoEQFa48BqEHcANLs1qH+r7vzL2SS8V39MzgnJ1yQA==}
-    peerDependencies:
-      d3-dispatch: '*'
-      d3-selection: '*'
-
-  '@d3fc/d3fc-random-data@4.0.2':
-    resolution: {integrity: sha512-T7+PbG1n23jyVMOWIuHJjY12PhPcYeRShuF0MK0ohifcNmwslurFMQKLBWkZk4x19In6JX7lNR0lwsaUUrcZNA==}
-    peerDependencies:
-      d3-random: '*'
-      d3-time: '*'
-
-  '@d3fc/d3fc-rebind@6.0.1':
-    resolution: {integrity: sha512-+ryBZ53ALMffbADwnFAtTYQJcT7PE5BwpducGYS0X6Jux6ESnp+fP+cDQvBGbDBOVqaziGnfeLeJXjtMnZujmQ==}
-
-  '@d3fc/d3fc-sample@5.0.2':
-    resolution: {integrity: sha512-+ZJu+TOL4MFzFvAYc+QqDKude9DS7x4uK+133vCknAlSxL/l8Sh6ecWFXTSaC8tqHGywT7SK1arf0DiYCyS3Nw==}
-    peerDependencies:
-      d3-array: '*'
-
-  '@d3fc/d3fc-series@6.1.3':
-    resolution: {integrity: sha512-OSbt60SohTIib1xihX9ufneyJY7s9Feg9hvXVyEBZEBkwNE1NaeesZJ4nkmslu39RWuwsvpK3apL/XuBw7i5WA==}
-    peerDependencies:
-      d3-array: '*'
-      d3-scale: '*'
-      d3-scale-chromatic: '*'
-      d3-selection: '*'
-      d3-shape: '*'
-
-  '@d3fc/d3fc-shape@6.0.1':
-    resolution: {integrity: sha512-/dD3S8BWrOjO2mSptUmwe38V7KG4Kw6liIE5NXZJjX/XidfZhuDu7WWuya3i90HeNYDZNcs6Z+4qM3FnvlZf8g==}
-    peerDependencies:
-      d3-path: '*'
-
-  '@d3fc/d3fc-technical-indicator@8.1.1':
-    resolution: {integrity: sha512-ci5q+/4jCbbnT9M/JnrsBoHJfNJI4HFeCGVT+sy221OTdaFnrLj+IELFKFUS2h0uEOSu+CYT3D1K0BcAnMooxA==}
-    peerDependencies:
-      d3-array: '*'
-
-  '@d3fc/d3fc-webgl@3.2.1':
-    resolution: {integrity: sha512-yNYHW/tC05rrJs5fpVM5zdmInL8NH6UP09ZJ2tmKw62ELYHWySV8vuXOVZN3V/3WihPa60p2w23H0Hrp2b5qeg==}
-    peerDependencies:
-      d3-scale: '*'
-      d3-shape: '*'
-
-  '@d3fc/d3fc-zoom@1.2.0':
-    resolution: {integrity: sha512-NfY6gPfcatw1gUtZoWq17SA7LV00t7Rl3eq6Bgj17++7K1H77Gpsb1hFa3XhzF85RrODuUzQW33/IIMYPgim9A==}
-    peerDependencies:
-      d3-dispatch: '*'
-      d3-selection: '*'
-      d3-zoom: '*'
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -384,33 +271,30 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@perspective-dev/client@4.5.0':
-    resolution: {integrity: sha512-eTJqHvmZOFvr+QDOZlmg6vmYuL7CtDAawFSGWhzuYw50PdC0osdKIvQmcoTY5eUcekNRCrOwGaGlp+KihpCAkA==}
+  '@perspective-dev/client@4.5.1':
+    resolution: {integrity: sha512-Yb/huLDHEQ9FFeTloipHKM2oVtgTkHLIEqh971eznOc0sNQGg9Sd7flju8xlKe8KMGe3VCo7/wlvxr4GqBi1Bw==}
 
-  '@perspective-dev/react@4.5.0':
-    resolution: {integrity: sha512-ieQKMJvG1okCsrhJzk8Er6iNktS5nb3p+dlapb032k+TZzwVEesFhwVN/3+H664Rn5YQq2E/ztXhREPbryHjRQ==}
+  '@perspective-dev/react@4.5.1':
+    resolution: {integrity: sha512-GIQIzMS/06HO0gMh46MUVwnezw32OtpbNCY7SiM7PSVUVe4v/AXiBytiSPlbWfD7j+Zh5QRh2o1z41Rx7D5h6Q==}
 
-  '@perspective-dev/server@4.5.0':
-    resolution: {integrity: sha512-1A3p1DOvS+U3Zc2eiRz0IkJYelLZ2VfmPh1w53qjI44lZAbQLYCMAq5iTSV1wgrL9P5sLliArjVCNMaIh0COBA==}
+  '@perspective-dev/server@4.5.1':
+    resolution: {integrity: sha512-VzR1Z+SdUlB4K1hTHFxVE7PLxFXtTb008fBGMg/uo3Y3qDbJh/9IcZjOwvpI86k6QUZ49VR2w3BDGdh7YzF/8A==}
 
-  '@perspective-dev/viewer-d3fc@4.4.1':
-    resolution: {integrity: sha512-sVM0DAP1hLWjenkRZRBVZ1PEEtzvFITvFeoR2R9Iqdfhrkj6qaW/m1dmRkCEnenCSpbXuOD35Y2g2wxwmp7Fqg==}
+  '@perspective-dev/viewer-charts@4.5.1':
+    resolution: {integrity: sha512-O4M45uav+zhommqEQJs05lc2G9/OvAIBUYux04s6TP5zxEuCCZjfAfCJKVLB4rTIeZJGES+lcXoCahktFCMLZg==}
 
-  '@perspective-dev/viewer-datagrid@4.5.0':
-    resolution: {integrity: sha512-1q0OVryjJm4oohStaEVnV+NUGOUMoy/h1gg/K5JMwxjwFbM8xUxmA28baaPpgwUVTFasMBk1h9BiHYQlzcZ5kw==}
+  '@perspective-dev/viewer-datagrid@4.5.1':
+    resolution: {integrity: sha512-MQyAzigizk32zgZori/8jbWptRJ2UQATi8XaBO9xTcSarr0noDsPp1wxHIDOCSkxoX+0LBOkro+LmQ5AAnLWgw==}
 
-  '@perspective-dev/viewer@4.5.0':
-    resolution: {integrity: sha512-WoOAgG91Rrp08f/IBbHOjp4rVmdR47krP3H7j6CUUQzpbd3srDWli1aTDm1fM1SS2jMYtwc1NKfx93cwJQPVnw==}
+  '@perspective-dev/viewer@4.5.1':
+    resolution: {integrity: sha512-dILBJOlVKwIXwTFkwSJL9ZBk1QQKKnQrgg9CBCZCJEiqe2+ApgW0UlT1XzCCK4uuwHAVHtBaNow237iDqWSf3A==}
 
-  '@perspective-dev/workspace@4.5.0':
-    resolution: {integrity: sha512-vro/EhuFen6f3UnYLKGbF9O6j3PzNOwEAduWVXCNCsD+r6ptovhuurBjh/nP5rIwJ1u/nWYXFcdcbIm0ff4cvg==}
+  '@perspective-dev/workspace@4.5.1':
+    resolution: {integrity: sha512-9hVsVHu6sKwRQkP2ChmIlI/W6ieA2Mr49OiSHVSicEw28INbMZgaEU/Pn21pIsg0S+VOgxcu/b07f37GajSecA==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
-
-  '@types/d3-selection@1.0.10':
-    resolution: {integrity: sha512-mHICSFHpIwgTycsvgINYCwItk039eofbGRzVNdeUUtv0S2BD1vXFFUKaeMJN3ARbVl+hlsVOIwdzhzub5tjr6Q==}
 
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
@@ -482,9 +366,6 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chroma-js@3.2.0:
-    resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
-
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
@@ -497,10 +378,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  commander@7.2.0:
-    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
-    engines: {node: '>= 10'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -523,178 +400,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  d3-array@1.0.1:
-    resolution: {integrity: sha512-VPS5OH5Xb43tkFkxHEc4r5yWhlDwST47zh1q+qvgTj7xB9xDXn+UEcofhvNC7s8gD55y9Q/MCSPSBUVvnzo3Dw==}
-
-  d3-array@3.2.4:
-    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
-    engines: {node: '>=12'}
-
-  d3-axis@3.0.0:
-    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
-    engines: {node: '>=12'}
-
-  d3-brush@3.0.0:
-    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
-    engines: {node: '>=12'}
-
-  d3-chord@3.0.1:
-    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
-    engines: {node: '>=12'}
-
-  d3-collection@1.0.7:
-    resolution: {integrity: sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==}
-
-  d3-color@1.4.1:
-    resolution: {integrity: sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==}
-
-  d3-color@3.1.0:
-    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
-    engines: {node: '>=12'}
-
-  d3-contour@4.0.2:
-    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
-    engines: {node: '>=12'}
-
-  d3-delaunay@6.0.4:
-    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
-    engines: {node: '>=12'}
-
-  d3-dispatch@1.0.1:
-    resolution: {integrity: sha512-BRTp95mobTSKx8EtpOLbxXuYVtNNr0PmelkH9Uzg5cgcO5O1M0i3+2C0FeM2I95BwQoIlsuZXQTPIoIt5xOtmw==}
-
-  d3-dispatch@3.0.1:
-    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
-    engines: {node: '>=12'}
-
-  d3-drag@3.0.0:
-    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
-    engines: {node: '>=12'}
-
-  d3-dsv@3.0.1:
-    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
-    engines: {node: '>=12'}
-    hasBin: true
-
-  d3-ease@1.0.7:
-    resolution: {integrity: sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==}
-
-  d3-ease@3.0.1:
-    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
-
-  d3-fetch@3.0.1:
-    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
-    engines: {node: '>=12'}
-
-  d3-force@3.0.0:
-    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
-    engines: {node: '>=12'}
-
-  d3-format@1.0.2:
-    resolution: {integrity: sha512-VHFdLLjGkeGrRL8T/rlIIDhI3vvVX/oOTM/GaDJfB1sIb4dU5ZgiEjg3EeidJdQ/70u60tM015TSWa1gqqLRhg==}
-
-  d3-format@3.1.2:
-    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
-    engines: {node: '>=12'}
-
-  d3-geo@3.1.1:
-    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
-    engines: {node: '>=12'}
-
-  d3-hierarchy@3.1.2:
-    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
-    engines: {node: '>=12'}
-
-  d3-interpolate@1.4.0:
-    resolution: {integrity: sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==}
-
-  d3-interpolate@3.0.1:
-    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
-    engines: {node: '>=12'}
-
-  d3-path@3.1.0:
-    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
-    engines: {node: '>=12'}
-
-  d3-polygon@3.0.1:
-    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
-    engines: {node: '>=12'}
-
-  d3-quadtree@3.0.1:
-    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
-    engines: {node: '>=12'}
-
-  d3-random@3.0.1:
-    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
-    engines: {node: '>=12'}
-
-  d3-scale-chromatic@3.1.0:
-    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
-    engines: {node: '>=12'}
-
-  d3-scale@1.0.3:
-    resolution: {integrity: sha512-ah2Xqywu96gau2iET3T0ZTsu0/X0gfoB8vDTuZ1OaG5F0SgGJLXreBVBknSZf2HKnxjenRvFok3qY2FgY4RpFg==}
-
-  d3-scale@4.0.2:
-    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
-
-  d3-selection@1.0.2:
-    resolution: {integrity: sha512-nInNdsdhljkDqkU/83bdWwtiJ7xsX3l57YZMlqsAOMeQROeCv7osPqQgYnao0NmRZEGc11hNakY+EOkaIdsWpQ==}
-
-  d3-selection@3.0.0:
-    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
-    engines: {node: '>=12'}
-
-  d3-shape@3.2.0:
-    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
-    engines: {node: '>=12'}
-
-  d3-svg-legend@2.25.6:
-    resolution: {integrity: sha512-6dueSjQr3+g9SlQ1SOzc4V58cCjjBeyo4WEcY8PW80i9XD/s562W/4xk05bpky0vzQx+i2XmXj3CYT+9KIRlnw==}
-
-  d3-time-format@2.3.0:
-    resolution: {integrity: sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==}
-
-  d3-time-format@4.1.0:
-    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
-    engines: {node: '>=12'}
-
-  d3-time@1.1.0:
-    resolution: {integrity: sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==}
-
-  d3-time@3.1.0:
-    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
-    engines: {node: '>=12'}
-
-  d3-timer@1.0.10:
-    resolution: {integrity: sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==}
-
-  d3-timer@3.0.1:
-    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
-
-  d3-transition@1.0.3:
-    resolution: {integrity: sha512-Facxcbma0nA2GVrx7B/Mgnn5ju6SwUMzGa9YcYmQjpqmaIq1Zbp5vVJLjtH6b08Lu0vcX7O6a4z+AlLmdCxrCQ==}
-
-  d3-transition@3.0.1:
-    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      d3-selection: 2 - 3
-
-  d3-zoom@3.0.0:
-    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
-    engines: {node: '>=12'}
-
-  d3@7.9.0:
-    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
-    engines: {node: '>=12'}
-
-  d3fc@15.2.13:
-    resolution: {integrity: sha512-wfBvY9TcoeV/bRxPjawlzDHS/r2y03STspyZc9ydiz4ANMt+y+ynL9oahTZ4aAbp5JK850VxWNkQ8jaaN/cDYg==}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -724,9 +429,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  delaunator@5.1.0:
-    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -844,10 +546,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  gradient-parser@1.2.0:
-    resolution: {integrity: sha512-6ABGa9CR7WR/0pAJicBy5SJkiikbFM6kf/JjykwX7x+t+s8ORWVnlbi6FkHeFFb36yWsjUpHqSYrygd7ofEUqA==}
-    engines: {node: '>=0.10.0'}
-
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -910,10 +608,6 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
-
-  internmap@2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1073,28 +767,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1295,14 +985,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  robust-predicates@3.0.3:
-    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
-  rw@1.3.3:
-    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
@@ -1513,137 +1197,6 @@ packages:
 
 snapshots:
 
-  '@d3fc/d3fc-annotation@3.0.16(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)':
-    dependencies:
-      '@d3fc/d3fc-data-join': 6.0.3(d3-selection@3.0.0)
-      '@d3fc/d3fc-rebind': 6.0.1
-      '@d3fc/d3fc-series': 6.1.3(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
-      '@d3fc/d3fc-shape': 6.0.1(d3-path@3.1.0)
-      d3-scale: 4.0.2
-      d3-selection: 3.0.0
-    transitivePeerDependencies:
-      - d3-array
-      - d3-path
-      - d3-scale-chromatic
-      - d3-shape
-
-  '@d3fc/d3fc-axis@3.0.7(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)':
-    dependencies:
-      '@d3fc/d3fc-data-join': 6.0.3(d3-selection@3.0.0)
-      '@d3fc/d3fc-rebind': 6.0.1
-      d3-scale: 4.0.2
-      d3-selection: 3.0.0
-      d3-shape: 3.2.0
-
-  '@d3fc/d3fc-brush@3.0.3(d3-brush@3.0.0)(d3-dispatch@3.0.1)(d3-scale@4.0.2)(d3-selection@3.0.0)':
-    dependencies:
-      '@d3fc/d3fc-data-join': 6.0.3(d3-selection@3.0.0)
-      '@d3fc/d3fc-rebind': 6.0.1
-      d3-brush: 3.0.0
-      d3-dispatch: 3.0.1
-      d3-scale: 4.0.2
-      d3-selection: 3.0.0
-
-  '@d3fc/d3fc-chart@5.1.9(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)':
-    dependencies:
-      '@d3fc/d3fc-axis': 3.0.7(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
-      '@d3fc/d3fc-data-join': 6.0.3(d3-selection@3.0.0)
-      '@d3fc/d3fc-element': 6.2.0
-      '@d3fc/d3fc-rebind': 6.0.1
-      '@d3fc/d3fc-series': 6.1.3(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
-      d3-scale: 4.0.2
-      d3-selection: 3.0.0
-    transitivePeerDependencies:
-      - d3-array
-      - d3-path
-      - d3-scale-chromatic
-      - d3-shape
-
-  '@d3fc/d3fc-data-join@6.0.3(d3-selection@3.0.0)':
-    dependencies:
-      d3-selection: 3.0.0
-
-  '@d3fc/d3fc-discontinuous-scale@4.1.1(d3-scale@4.0.2)(d3-time@3.1.0)':
-    dependencies:
-      '@d3fc/d3fc-rebind': 6.0.1
-      d3-scale: 4.0.2
-      d3-time: 3.1.0
-
-  '@d3fc/d3fc-element@6.2.0': {}
-
-  '@d3fc/d3fc-extent@4.0.2(d3-array@3.2.4)':
-    dependencies:
-      d3-array: 3.2.4
-
-  '@d3fc/d3fc-financial-feed@7.1.0(d3-fetch@3.0.1)':
-    dependencies:
-      d3-fetch: 3.0.1
-
-  '@d3fc/d3fc-group@3.0.1': {}
-
-  '@d3fc/d3fc-label-layout@7.0.4(d3-array@3.2.4)(d3-scale@4.0.2)(d3-selection@3.0.0)':
-    dependencies:
-      '@d3fc/d3fc-data-join': 6.0.3(d3-selection@3.0.0)
-      '@d3fc/d3fc-rebind': 6.0.1
-      d3-array: 3.2.4
-      d3-scale: 4.0.2
-      d3-selection: 3.0.0
-
-  '@d3fc/d3fc-pointer@3.0.3(d3-dispatch@3.0.1)(d3-selection@3.0.0)':
-    dependencies:
-      '@d3fc/d3fc-rebind': 6.0.1
-      d3-dispatch: 3.0.1
-      d3-selection: 3.0.0
-
-  '@d3fc/d3fc-random-data@4.0.2(d3-random@3.0.1)(d3-time@3.1.0)':
-    dependencies:
-      '@d3fc/d3fc-rebind': 6.0.1
-      d3-random: 3.0.1
-      d3-time: 3.1.0
-
-  '@d3fc/d3fc-rebind@6.0.1': {}
-
-  '@d3fc/d3fc-sample@5.0.2(d3-array@3.2.4)':
-    dependencies:
-      '@d3fc/d3fc-rebind': 6.0.1
-      d3-array: 3.2.4
-
-  '@d3fc/d3fc-series@6.1.3(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)':
-    dependencies:
-      '@d3fc/d3fc-data-join': 6.0.3(d3-selection@3.0.0)
-      '@d3fc/d3fc-rebind': 6.0.1
-      '@d3fc/d3fc-shape': 6.0.1(d3-path@3.1.0)
-      '@d3fc/d3fc-webgl': 3.2.1(d3-scale@4.0.2)(d3-shape@3.2.0)
-      d3-array: 3.2.4
-      d3-scale: 4.0.2
-      d3-scale-chromatic: 3.1.0
-      d3-selection: 3.0.0
-      d3-shape: 3.2.0
-    transitivePeerDependencies:
-      - d3-path
-
-  '@d3fc/d3fc-shape@6.0.1(d3-path@3.1.0)':
-    dependencies:
-      d3-path: 3.1.0
-
-  '@d3fc/d3fc-technical-indicator@8.1.1(d3-array@3.2.4)':
-    dependencies:
-      '@d3fc/d3fc-rebind': 6.0.1
-      d3-array: 3.2.4
-
-  '@d3fc/d3fc-webgl@3.2.1(d3-scale@4.0.2)(d3-shape@3.2.0)':
-    dependencies:
-      '@d3fc/d3fc-rebind': 6.0.1
-      d3-scale: 4.0.2
-      d3-shape: 3.2.0
-
-  '@d3fc/d3fc-zoom@1.2.0(d3-dispatch@3.0.1)(d3-selection@3.0.0)(d3-zoom@3.0.0)':
-    dependencies:
-      '@d3fc/d3fc-rebind': 6.0.1
-      d3-dispatch: 3.0.1
-      d3-selection: 3.0.0
-      d3-zoom: 3.0.0
-
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
@@ -1797,9 +1350,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@perspective-dev/client@4.5.0':
+  '@perspective-dev/client@4.5.1':
     dependencies:
-      '@perspective-dev/server': 4.5.0
+      '@perspective-dev/server': 4.5.1
       pro_self_extracting_wasm: 0.0.9
       stoppable: 1.1.0
       ws: 8.20.1
@@ -1809,11 +1362,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@perspective-dev/react@4.5.0':
+  '@perspective-dev/react@4.5.1':
     dependencies:
-      '@perspective-dev/client': 4.5.0
-      '@perspective-dev/viewer': 4.5.0
-      '@perspective-dev/workspace': 4.5.0
+      '@perspective-dev/client': 4.5.1
+      '@perspective-dev/viewer': 4.5.1
+      '@perspective-dev/workspace': 4.5.1
       '@types/react': 19.2.15
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -1823,42 +1376,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@perspective-dev/server@4.5.0': {}
+  '@perspective-dev/server@4.5.1': {}
 
-  '@perspective-dev/viewer-d3fc@4.4.1(d3-brush@3.0.0)(d3-dispatch@3.0.1)(d3-fetch@3.0.1)(d3-path@3.1.0)(d3-random@3.0.1)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-shape@3.2.0)(d3-time@3.1.0)(d3-zoom@3.0.0)':
-    dependencies:
-      '@d3fc/d3fc-chart': 5.1.9(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
-      '@d3fc/d3fc-element': 6.2.0
-      '@perspective-dev/client': 4.5.0
-      '@perspective-dev/viewer': 4.5.0
-      chroma-js: 3.2.0
-      d3: 7.9.0
-      d3-array: 3.2.4
-      d3-color: 3.1.0
-      d3-selection: 3.0.0
-      d3-svg-legend: 2.25.6
-      d3fc: 15.2.13(d3-array@3.2.4)(d3-brush@3.0.0)(d3-dispatch@3.0.1)(d3-fetch@3.0.1)(d3-path@3.1.0)(d3-random@3.0.1)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)(d3-time@3.1.0)(d3-zoom@3.0.0)
-      gradient-parser: 1.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - d3-brush
-      - d3-dispatch
-      - d3-fetch
-      - d3-path
-      - d3-random
-      - d3-scale
-      - d3-scale-chromatic
-      - d3-shape
-      - d3-time
-      - d3-zoom
-      - debug
-      - supports-color
-      - utf-8-validate
+  '@perspective-dev/viewer-charts@4.5.1': {}
 
-  '@perspective-dev/viewer-datagrid@4.5.0':
+  '@perspective-dev/viewer-datagrid@4.5.1':
     dependencies:
-      '@perspective-dev/client': 4.5.0
-      '@perspective-dev/viewer': 4.5.0
+      '@perspective-dev/client': 4.5.1
+      '@perspective-dev/viewer': 4.5.1
       regular-table: 0.8.4
     transitivePeerDependencies:
       - bufferutil
@@ -1866,9 +1391,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@perspective-dev/viewer@4.5.0':
+  '@perspective-dev/viewer@4.5.1':
     dependencies:
-      '@perspective-dev/client': 4.5.0
+      '@perspective-dev/client': 4.5.1
       pro_self_extracting_wasm: 0.0.9
     transitivePeerDependencies:
       - bufferutil
@@ -1876,7 +1401,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@perspective-dev/workspace@4.5.0':
+  '@perspective-dev/workspace@4.5.1':
     dependencies:
       '@lumino/algorithm': 2.0.4
       '@lumino/commands': 2.3.3
@@ -1886,7 +1411,7 @@ snapshots:
       '@lumino/signaling': 2.1.5
       '@lumino/virtualdom': 2.0.4
       '@lumino/widgets': 2.7.5
-      '@perspective-dev/client': 4.5.0
+      '@perspective-dev/client': 4.5.1
       lodash: 4.18.1
     transitivePeerDependencies:
       - bufferutil
@@ -1895,8 +1420,6 @@ snapshots:
       - utf-8-validate
 
   '@sindresorhus/merge-streams@4.0.0': {}
-
-  '@types/d3-selection@1.0.10': {}
 
   '@types/react@19.2.15':
     dependencies:
@@ -1982,8 +1505,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chroma-js@3.2.0: {}
-
   color-convert@1.9.3:
     dependencies:
       color-name: 1.1.3
@@ -1995,8 +1516,6 @@ snapshots:
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
-
-  commander@7.2.0: {}
 
   concat-map@0.0.1: {}
 
@@ -2025,249 +1544,6 @@ snapshots:
       which: 1.3.1
 
   csstype@3.2.3: {}
-
-  d3-array@1.0.1: {}
-
-  d3-array@3.2.4:
-    dependencies:
-      internmap: 2.0.3
-
-  d3-axis@3.0.0: {}
-
-  d3-brush@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-
-  d3-chord@3.0.1:
-    dependencies:
-      d3-path: 3.1.0
-
-  d3-collection@1.0.7: {}
-
-  d3-color@1.4.1: {}
-
-  d3-color@3.1.0: {}
-
-  d3-contour@4.0.2:
-    dependencies:
-      d3-array: 3.2.4
-
-  d3-delaunay@6.0.4:
-    dependencies:
-      delaunator: 5.1.0
-
-  d3-dispatch@1.0.1: {}
-
-  d3-dispatch@3.0.1: {}
-
-  d3-drag@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-selection: 3.0.0
-
-  d3-dsv@3.0.1:
-    dependencies:
-      commander: 7.2.0
-      iconv-lite: 0.6.3
-      rw: 1.3.3
-
-  d3-ease@1.0.7: {}
-
-  d3-ease@3.0.1: {}
-
-  d3-fetch@3.0.1:
-    dependencies:
-      d3-dsv: 3.0.1
-
-  d3-force@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-quadtree: 3.0.1
-      d3-timer: 3.0.1
-
-  d3-format@1.0.2: {}
-
-  d3-format@3.1.2: {}
-
-  d3-geo@3.1.1:
-    dependencies:
-      d3-array: 3.2.4
-
-  d3-hierarchy@3.1.2: {}
-
-  d3-interpolate@1.4.0:
-    dependencies:
-      d3-color: 1.4.1
-
-  d3-interpolate@3.0.1:
-    dependencies:
-      d3-color: 3.1.0
-
-  d3-path@3.1.0: {}
-
-  d3-polygon@3.0.1: {}
-
-  d3-quadtree@3.0.1: {}
-
-  d3-random@3.0.1: {}
-
-  d3-scale-chromatic@3.1.0:
-    dependencies:
-      d3-color: 3.1.0
-      d3-interpolate: 3.0.1
-
-  d3-scale@1.0.3:
-    dependencies:
-      d3-array: 1.0.1
-      d3-collection: 1.0.7
-      d3-color: 1.4.1
-      d3-format: 1.0.2
-      d3-interpolate: 1.4.0
-      d3-time: 1.1.0
-      d3-time-format: 2.3.0
-
-  d3-scale@4.0.2:
-    dependencies:
-      d3-array: 3.2.4
-      d3-format: 3.1.2
-      d3-interpolate: 3.0.1
-      d3-time: 3.1.0
-      d3-time-format: 4.1.0
-
-  d3-selection@1.0.2: {}
-
-  d3-selection@3.0.0: {}
-
-  d3-shape@3.2.0:
-    dependencies:
-      d3-path: 3.1.0
-
-  d3-svg-legend@2.25.6:
-    dependencies:
-      '@types/d3-selection': 1.0.10
-      d3-array: 1.0.1
-      d3-dispatch: 1.0.1
-      d3-format: 1.0.2
-      d3-scale: 1.0.3
-      d3-selection: 1.0.2
-      d3-transition: 1.0.3
-
-  d3-time-format@2.3.0:
-    dependencies:
-      d3-time: 1.1.0
-
-  d3-time-format@4.1.0:
-    dependencies:
-      d3-time: 3.1.0
-
-  d3-time@1.1.0: {}
-
-  d3-time@3.1.0:
-    dependencies:
-      d3-array: 3.2.4
-
-  d3-timer@1.0.10: {}
-
-  d3-timer@3.0.1: {}
-
-  d3-transition@1.0.3:
-    dependencies:
-      d3-color: 1.4.1
-      d3-dispatch: 1.0.1
-      d3-ease: 1.0.7
-      d3-interpolate: 1.4.0
-      d3-selection: 1.0.2
-      d3-timer: 1.0.10
-
-  d3-transition@3.0.1(d3-selection@3.0.0):
-    dependencies:
-      d3-color: 3.1.0
-      d3-dispatch: 3.0.1
-      d3-ease: 3.0.1
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-timer: 3.0.1
-
-  d3-zoom@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-
-  d3@7.9.0:
-    dependencies:
-      d3-array: 3.2.4
-      d3-axis: 3.0.0
-      d3-brush: 3.0.0
-      d3-chord: 3.0.1
-      d3-color: 3.1.0
-      d3-contour: 4.0.2
-      d3-delaunay: 6.0.4
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-dsv: 3.0.1
-      d3-ease: 3.0.1
-      d3-fetch: 3.0.1
-      d3-force: 3.0.0
-      d3-format: 3.1.2
-      d3-geo: 3.1.1
-      d3-hierarchy: 3.1.2
-      d3-interpolate: 3.0.1
-      d3-path: 3.1.0
-      d3-polygon: 3.0.1
-      d3-quadtree: 3.0.1
-      d3-random: 3.0.1
-      d3-scale: 4.0.2
-      d3-scale-chromatic: 3.1.0
-      d3-selection: 3.0.0
-      d3-shape: 3.2.0
-      d3-time: 3.1.0
-      d3-time-format: 4.1.0
-      d3-timer: 3.0.1
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-      d3-zoom: 3.0.0
-
-  d3fc@15.2.13(d3-array@3.2.4)(d3-brush@3.0.0)(d3-dispatch@3.0.1)(d3-fetch@3.0.1)(d3-path@3.1.0)(d3-random@3.0.1)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)(d3-time@3.1.0)(d3-zoom@3.0.0):
-    dependencies:
-      '@d3fc/d3fc-annotation': 3.0.16(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
-      '@d3fc/d3fc-axis': 3.0.7(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
-      '@d3fc/d3fc-brush': 3.0.3(d3-brush@3.0.0)(d3-dispatch@3.0.1)(d3-scale@4.0.2)(d3-selection@3.0.0)
-      '@d3fc/d3fc-chart': 5.1.9(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
-      '@d3fc/d3fc-data-join': 6.0.3(d3-selection@3.0.0)
-      '@d3fc/d3fc-discontinuous-scale': 4.1.1(d3-scale@4.0.2)(d3-time@3.1.0)
-      '@d3fc/d3fc-element': 6.2.0
-      '@d3fc/d3fc-extent': 4.0.2(d3-array@3.2.4)
-      '@d3fc/d3fc-financial-feed': 7.1.0(d3-fetch@3.0.1)
-      '@d3fc/d3fc-group': 3.0.1
-      '@d3fc/d3fc-label-layout': 7.0.4(d3-array@3.2.4)(d3-scale@4.0.2)(d3-selection@3.0.0)
-      '@d3fc/d3fc-pointer': 3.0.3(d3-dispatch@3.0.1)(d3-selection@3.0.0)
-      '@d3fc/d3fc-random-data': 4.0.2(d3-random@3.0.1)(d3-time@3.1.0)
-      '@d3fc/d3fc-rebind': 6.0.1
-      '@d3fc/d3fc-sample': 5.0.2(d3-array@3.2.4)
-      '@d3fc/d3fc-series': 6.1.3(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
-      '@d3fc/d3fc-shape': 6.0.1(d3-path@3.1.0)
-      '@d3fc/d3fc-technical-indicator': 8.1.1(d3-array@3.2.4)
-      '@d3fc/d3fc-webgl': 3.2.1(d3-scale@4.0.2)(d3-shape@3.2.0)
-      '@d3fc/d3fc-zoom': 1.2.0(d3-dispatch@3.0.1)(d3-selection@3.0.0)(d3-zoom@3.0.0)
-    transitivePeerDependencies:
-      - d3-array
-      - d3-brush
-      - d3-dispatch
-      - d3-fetch
-      - d3-path
-      - d3-random
-      - d3-scale
-      - d3-scale-chromatic
-      - d3-selection
-      - d3-shape
-      - d3-time
-      - d3-zoom
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -2302,10 +1578,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-
-  delaunator@5.1.0:
-    dependencies:
-      robust-predicates: 3.0.3
 
   detect-libc@2.1.2: {}
 
@@ -2513,8 +1785,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  gradient-parser@1.2.0: {}
-
   has-bigints@1.1.0: {}
 
   has-flag@3.0.0: {}
@@ -2585,8 +1855,6 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
-
-  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -2945,13 +2213,9 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  robust-predicates@3.0.3: {}
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  rw@1.3.3: {}
 
   safe-array-concat@1.1.4:
     dependencies:

--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 allowBuilds:
   esbuild: true
 
+onlyBuiltDependencies:
+  - esbuild
+
 overrides:
   react: 19.2.6
   react-dom: 19.2.6

--- a/js/src/js/components/perspective/layout.js
+++ b/js/src/js/components/perspective/layout.js
@@ -14,6 +14,28 @@ export const saveCustomLayout = (layout) => {
   );
 };
 
+/**
+ * Strip transient fields from a layout so it is theme/mode-agnostic.
+ * Fields like `theme` are re-applied on restore based on the user's current
+ * settings, and column sizing is screen-dependent — persisting them would
+ * override future preferences or look wrong on different displays.
+ */
+export const stripTransientFields = (layout) => {
+  const cloned = structuredClone(layout);
+  if (cloned?.viewers) {
+    Object.values(cloned.viewers).forEach((viewer) => {
+      delete viewer.theme;
+      // Strip datagrid column width overrides from plugin_config
+      if (viewer.plugin_config?.columns) {
+        for (const col of Object.values(viewer.plugin_config.columns)) {
+          delete col.column_size_override;
+        }
+      }
+    });
+  }
+  return cloned;
+};
+
 /** Fetch server-defined layouts from the gateway API */
 export const getServerLayouts = async () => {
   const data = await fetch(

--- a/js/src/js/components/perspective/tables.js
+++ b/js/src/js/components/perspective/tables.js
@@ -5,7 +5,7 @@ import CLIENT_WASM from "@perspective-dev/viewer/dist/wasm/perspective-viewer.wa
 
 import "@perspective-dev/workspace";
 import "@perspective-dev/viewer-datagrid";
-import "@perspective-dev/viewer-d3fc";
+import "@perspective-dev/viewer-charts";
 
 const perspective_init_promise = Promise.all([
   perspective.init_server(fetch(SERVER_WASM)),

--- a/js/src/js/components/perspective/workspace.jsx
+++ b/js/src/js/components/perspective/workspace.jsx
@@ -14,6 +14,7 @@ import {
   saveCustomLayout,
   getUrlLayout,
   setUrlLayout,
+  stripTransientFields,
 } from "./layout";
 import { getCurrentTheme, getViewerTheme } from "./theme";
 
@@ -119,7 +120,7 @@ export const Workspace = forwardRef(function Workspace(
         await restoreQueueRef.current.catch(() => {});
         const ws = wsRef.current;
         if (!ws) return;
-        const config = await ws.save();
+        const config = stripTransientFields(await ws.save());
         saveCustomLayout(config);
         setLayouts((prev) => ({ ...prev, "Custom Layout": config }));
         setActiveLayoutName("Custom Layout");
@@ -128,7 +129,7 @@ export const Workspace = forwardRef(function Workspace(
         await restoreQueueRef.current.catch(() => {});
         const ws = wsRef.current;
         if (!ws) return null;
-        const config = await ws.save();
+        const config = stripTransientFields(await ws.save());
         return JSON.stringify(config).replace(
           /PERSPECTIVE_GENERATED_/g,
           "CSP_GATEWAY_GENERATED_",
@@ -214,7 +215,7 @@ export const Workspace = forwardRef(function Workspace(
       ws.addEventListener("workspace-layout-update", async () => {
         if (!initializedRef.current || restoringRef.current) return;
         try {
-          const config = await ws.save();
+          const config = stripTransientFields(await ws.save());
           if (!restoringRef.current) {
             await setUrlLayout(config);
           }


### PR DESCRIPTION
This change allows registration of multiple perspective tables off the same columns via config.
Also bumps perspective JS for bugfixes and strips theme from perspective workspace config download as its driven at the csp-gateway level via light/dark selector.
