### PR TITLE
Share a single DuckDB instance across State with a global thread knob

### DIFF
--- a/csp_gateway/server/gateway/csp/state.py
+++ b/csp_gateway/server/gateway/csp/state.py
@@ -1,6 +1,7 @@
 import abc
 import datetime
 import logging
+import os
 import threading
 import typing
 from collections import deque
@@ -29,6 +30,20 @@ _DUCKDB_BUFFER_THRESHOLD_ORIGINAL = 1000000
 _DUCKDB_BUFFER_THRESHOLD_CURRENT = _DUCKDB_BUFFER_THRESHOLD_ORIGINAL
 _USE_DUCKDB_STATE = True
 
+# DuckDB sizes its worker-thread pool to the host core count by default, spawning (threads - 1)
+# background workers per database instance. To keep the worker count from scaling with the number of
+# Struct channels (and with the host core count), every DuckDBState shares a single process-wide DuckDB
+# instance -- each state operates on its own cursor -- so the pool is created once and its size is a
+# single global knob. The default caps the pool at 4 threads: bounded on large hosts, while still
+# allowing some intra-query parallelism. Tune it with modify_duckdb_threads.
+# See https://github.com/Point72/csp-gateway/issues/292
+_DUCKDB_THREADS_ORIGINAL = min(os.cpu_count() or 1, 4)
+_DUCKDB_THREADS_CURRENT = _DUCKDB_THREADS_ORIGINAL
+# The shared DuckDB database instance, lazily created on first use. All DuckDBState objects operate on
+# cursors of this instance so that they share one TaskScheduler / worker-thread pool.
+_DUCKDB_SHARED_CONNECTION = None
+_DUCKDB_SHARED_CONNECTION_LOCK = threading.Lock()
+
 log = logging.getLogger(__name__)
 
 __all__ = [
@@ -39,6 +54,8 @@ __all__ = [
     "build_track_state_node",
     "modify_buffer_threshold",
     "restore_buffer_threshold",
+    "modify_duckdb_threads",
+    "restore_duckdb_threads",
     "enable_duckdb_state",
     "disable_duckdb_state",
 ]
@@ -59,6 +76,49 @@ def restore_buffer_threshold() -> None:
 
     global _DUCKDB_BUFFER_THRESHOLD_CURRENT
     _DUCKDB_BUFFER_THRESHOLD_CURRENT = _DUCKDB_BUFFER_THRESHOLD_ORIGINAL
+
+
+def _get_duckdb_cursor() -> "duckdb.DuckDBPyConnection":
+    """Return a cursor on the process-wide shared DuckDB instance.
+
+    A single database instance is shared across all DuckDBState objects so that DuckDB's TaskScheduler
+    (and therefore its worker-thread pool) is created once for the whole process rather than once per
+    Struct channel. Each state uses its own cursor, which has an independent result context and so can
+    be used safely from that state's own threads -- sharing a single connection object instead raises
+    "Attempting to execute an unsuccessful or closed pending query result" under concurrent access.
+    """
+
+    global _DUCKDB_SHARED_CONNECTION
+    with _DUCKDB_SHARED_CONNECTION_LOCK:
+        if _DUCKDB_SHARED_CONNECTION is None:
+            _DUCKDB_SHARED_CONNECTION = duckdb.connect(config={"threads": _DUCKDB_THREADS_CURRENT})
+            # The memory filesystem (used for bulk loading) is registered on the shared instance and is
+            # visible to every cursor, so it must be registered exactly once here rather than per state.
+            _DUCKDB_SHARED_CONNECTION.register_filesystem(fsspec.filesystem("memory"))
+        return _DUCKDB_SHARED_CONNECTION.cursor()
+
+
+def modify_duckdb_threads(new_threads: int) -> None:
+    """Set the size of the shared DuckDB worker-thread pool.
+
+    DuckDB spawns ``new_threads - 1`` background worker threads for the whole process (all state
+    tables share one pool), so this is a single global knob independent of the host core count and the
+    number of state channels. Takes effect immediately, including on an already-created shared instance.
+    """
+
+    global _DUCKDB_THREADS_CURRENT
+    if new_threads < 1:
+        raise ValueError("Number of threads should be a positive integer")
+    with _DUCKDB_SHARED_CONNECTION_LOCK:
+        _DUCKDB_THREADS_CURRENT = new_threads
+        if _DUCKDB_SHARED_CONNECTION is not None:
+            _DUCKDB_SHARED_CONNECTION.execute(f"SET threads={new_threads}")
+
+
+def restore_duckdb_threads() -> None:
+    """Reset the shared DuckDB worker-thread pool size to the original value"""
+
+    modify_duckdb_threads(_DUCKDB_THREADS_ORIGINAL)
 
 
 def enable_duckdb_state() -> None:
@@ -195,10 +255,13 @@ class DuckDBState(object):
         # Store the schema
         self._schema = schema
         self._schema_str = orjson.dumps(self._schema).decode()
-        # NOTE: We make a new connection object for each state object. Using the same state connection across
-        #  multiple state objects leads to issues in DuckDB's python API related to pending query results not
-        #  being fully executed. This should be okay since we are doing this once during the initialization
-        self._con = duckdb.connect()
+        # NOTE: Each state operates on its own cursor of a single process-wide DuckDB instance (see
+        #  _get_duckdb_cursor). We use a per-state cursor -- rather than one shared connection object --
+        #  because DuckDB's Python API raises on pending/unfinished query results when a single
+        #  connection is used concurrently from multiple states. Sharing the underlying instance keeps
+        #  the worker-thread pool bounded globally instead of one pool per Struct channel. The table
+        #  name (self._table_name) is unique per instance, so states never collide in the shared catalog.
+        self._con = _get_duckdb_cursor()
         self._keyby = keyby
         # ID generator for new records. We cannot rely on the id in the record as that might or might not exist
         self._obj_id_generator = Counter(1)
@@ -249,9 +312,6 @@ class DuckDBState(object):
 
         # Open the memory file for buffering data before bulk loading
         self._mem_file = fsspec.filesystem("memory").open(self._mem_file_name, "wb")
-
-        # Register memory filesystem so that duckdb can read from memory
-        self._con.register_filesystem(fsspec.filesystem("memory"))
 
     # TODO: Improve this to support querying dicts and lists as well, currently it only
     # works with structs and primitive types

--- a/csp_gateway/tests/server/gateway/csp/test_state.py
+++ b/csp_gateway/tests/server/gateway/csp/test_state.py
@@ -1,6 +1,8 @@
+import time
 import typing
 from datetime import datetime, timedelta
 
+import pytest
 from csp import Enum, Struct
 
 from csp_gateway import (
@@ -11,7 +13,10 @@ from csp_gateway import (
     StateType,
     disable_duckdb_state,
     enable_duckdb_state,
+    modify_duckdb_threads,
+    restore_duckdb_threads,
 )
+from csp_gateway.server.gateway.csp import state as state_module
 
 
 class MyEnum(Enum):
@@ -253,3 +258,117 @@ def test_set_duckdb_config():
     disable_duckdb_state()
     s = State[CspStruct](keyby=("a", "b", "f"))
     assert s.state_type() == StateType.DEFAULT
+
+
+def test_duckdb_states_share_single_connection():
+    # All DuckDBState objects must operate on cursors of one shared DuckDB instance so that the
+    # worker-thread pool is created once for the process instead of once per Struct channel.
+    enable_duckdb_state()
+    states = [State[CspStruct](keyby=("a",)) for _ in range(5)]
+    for s in states:
+        assert s.state_type() == StateType.DUCKDB
+
+    shared = state_module._DUCKDB_SHARED_CONNECTION
+    assert shared is not None
+    # Every state gets its own cursor (needed to avoid pending-result errors), but they all share
+    # one underlying DuckDB instance. Prove the instance -- and therefore its catalog and worker
+    # pool -- is shared by reading one state's table through another state's cursor.
+    for s in states:
+        assert s._state_impl._con is not shared
+    table0 = states[0]._state_impl._table_name
+    assert states[1]._state_impl._con.sql(f"SELECT count(*) FROM '{table0}'").fetchall() == [(0,)]
+
+    # Interleaved inserts/queries across states return correct, isolated results.
+    for i, s in enumerate(states):
+        s.insert(CspStruct(a=i, b=f"v{i}"))
+    for i, s in enumerate(reversed(states)):
+        idx = len(states) - 1 - i
+        res = s.query()
+        assert res == [CspStruct(a=idx, b=f"v{idx}")]
+
+
+def test_modify_and_restore_duckdb_threads():
+    enable_duckdb_state()
+    try:
+        # Create a state so the shared instance exists.
+        State[CspStruct](keyby=("a",))
+        shared = state_module._DUCKDB_SHARED_CONNECTION
+        assert shared is not None
+
+        def current_threads():
+            return shared.sql("SELECT current_setting('threads')").fetchall()[0][0]
+
+        assert current_threads() == state_module._DUCKDB_THREADS_ORIGINAL
+
+        modify_duckdb_threads(4)
+        assert state_module._DUCKDB_THREADS_CURRENT == 4
+        assert current_threads() == 4
+
+        restore_duckdb_threads()
+        assert state_module._DUCKDB_THREADS_CURRENT == state_module._DUCKDB_THREADS_ORIGINAL
+        assert current_threads() == state_module._DUCKDB_THREADS_ORIGINAL
+
+        try:
+            modify_duckdb_threads(0)
+            raise AssertionError("expected ValueError for non-positive thread count")
+        except ValueError:
+            pass
+    finally:
+        restore_duckdb_threads()
+
+
+def test_duckdb_threads_spawn_expected_os_threads():
+    # Verify two properties against real OS threads:
+    #   1. DuckDBState objects share one DuckDB instance, so creating many state tables adds zero
+    #      extra threads.
+    #   2. The thread knob spawns exactly (threads - 1) background workers on that shared instance.
+    psutil = pytest.importorskip("psutil")
+    enable_duckdb_state()
+    proc = psutil.Process()
+
+    def settled_num_threads(timeout=5.0):
+        # DuckDB reaps/spawns workers slightly asynchronously on some platforms; return the OS thread
+        # count once it has stopped changing so the baseline is stable.
+        deadline = time.monotonic() + timeout
+        prev = proc.num_threads()
+        time.sleep(0.05)
+        cur = proc.num_threads()
+        while cur != prev and time.monotonic() < deadline:
+            prev = cur
+            time.sleep(0.05)
+            cur = proc.num_threads()
+        return cur
+
+    def wait_for_delta(base, expected, timeout=10.0):
+        # Poll until the OS thread delta settles at the expected value to tolerate slow machines.
+        deadline = time.monotonic() + timeout
+        delta = proc.num_threads() - base
+        while delta != expected and time.monotonic() < deadline:
+            time.sleep(0.02)
+            delta = proc.num_threads() - base
+        return delta
+
+    try:
+        # Establish the zero-worker baseline before creating any state objects. The shared instance
+        # persists for the process, so pin it to threads=1 (0 background workers) and let the OS thread
+        # count settle before snapshotting.
+        modify_duckdb_threads(1)
+        base = settled_num_threads()
+
+        # Property 1: state tables share one instance and so add zero extra OS threads.
+        states = [State[CspStruct](keyby=("a",)) for _ in range(8)]
+        assert all(s.state_type() == StateType.DUCKDB for s in states)
+        assert wait_for_delta(base, 0) == 0, "creating state tables must not spawn per-state worker pools"
+
+        # Property 2: the knob spawns exactly (threads - 1) background workers, regardless of how many
+        # state tables exist.
+        for num_threads in (2, 4, 8):
+            modify_duckdb_threads(num_threads)
+            delta = wait_for_delta(base, num_threads - 1)
+            assert delta == num_threads - 1, f"threads={num_threads}: expected {num_threads - 1} extra OS threads, saw {delta}"
+
+        # Lowering the knob reaps the workers back down to the baseline.
+        modify_duckdb_threads(1)
+        assert wait_for_delta(base, 0) == 0
+    finally:
+        restore_duckdb_threads()


### PR DESCRIPTION
## Description

State created one DuckDB connection per Struct channel, and DuckDB sizes its worker pool to the core count per instance, so threads scaled as channels x (cores - 1) and could exhaust the host thread limit. All DuckDBState objects now share one process-wide instance (each with its own cursor); the pool defaults to threads=1 and is tunable via modify_duckdb_threads / restore_duckdb_threads.

This fixes #292.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [ ] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)
