### PR TITLE
Add a live staging panel to the spaday UI

### DIFF
--- a/csp_gateway/server/config/gateway/omnibus.yaml
+++ b/csp_gateway/server/config/gateway/omnibus.yaml
@@ -44,6 +44,8 @@ modules:
     force_mount_all: True
   mount_send_form:
     _target_: csp_gateway.MountSendForm
+  mount_staging_panel:
+    _target_: csp_gateway.MountStagingPanel
   mount_websocket_routes:
     _target_: csp_gateway.MountWebSocketRoutes
 
@@ -52,6 +54,7 @@ gateway:
   settings:
     PORT: ${port}
     UI: True
+    UI_PROVIDER: spaday
   modules:
     - /modules/example_module
     - /modules/example_module_feedback
@@ -62,6 +65,7 @@ gateway:
     - /modules/mount_perspective_tables
     - /modules/mount_rest_routes
     - /modules/mount_send_form
+    - /modules/mount_staging_panel
     - /modules/mount_websocket_routes
   channels:
     _target_: csp_gateway.server.demo.ExampleGatewayChannels

--- a/csp_gateway/server/gateway/csp/channels.py
+++ b/csp_gateway/server/gateway/csp/channels.py
@@ -41,7 +41,7 @@ from .futures import (
     named_wait_for_next_node,
     named_wait_for_next_node_dict_basket,
 )
-from .stage import Stage, _StageManager, build_staging_node
+from .stage import Stage, _StageManager, apply_stage_requests, build_staging_node
 from .state import State, _StateManager, build_track_state_node
 
 if TYPE_CHECKING:
@@ -271,6 +271,8 @@ class Channels(BaseModel, metaclass=ChannelsMetaclass):
     _stages: dict[str, _StageManager] = PrivateAttr(default_factory=dict)
     # Staging: channel_name -> GenericPushAdapter (release trigger)
     _stage_triggers: dict[str, Any] = PrivateAttr(default_factory=dict)
+    # Staging: channel_name -> GenericPushAdapter (StagingEvent delta stream)
+    _stage_events: dict[str, Any] = PrivateAttr(default_factory=dict)
 
     # inside context, the module being attached
     _module_being_attached: Any = PrivateAttr(None)
@@ -561,9 +563,10 @@ class Channels(BaseModel, metaclass=ChannelsMetaclass):
             if _get_origin(element_type) is list:
                 element_type = _get_args(element_type)[0]
 
-            stage, push_adapter = build_staging_node(element_type)
+            stage, push_adapter, event_adapter = build_staging_node(element_type, field_name)
             self._stages[field_name] = stage
             self._stage_triggers[field_name] = push_adapter
+            self._stage_events[field_name] = event_adapter
 
             # Wire the push adapter's output as an additional provider for this channel
             self._delayed_edge_providers[field_name].append((None, push_adapter.out()))
@@ -1199,13 +1202,46 @@ class Channels(BaseModel, metaclass=ChannelsMetaclass):
         if _get_origin(element_type) is list:
             element_type = _get_args(element_type)[0]
 
-        stage, push_adapter = build_staging_node(element_type)
+        stage, push_adapter, event_adapter = build_staging_node(element_type, field)
         self._stages[field] = stage
         self._stage_triggers[field] = push_adapter
+        self._stage_events[field] = event_adapter
 
         # Wire the push adapter's output as an additional provider for this channel
         module = self._module_being_attached
         self._delayed_edge_providers[field].append((module, push_adapter.out()))
+
+    def get_stage_events(self, field: str) -> Any:
+        """The ``ts[StagingEvent]`` delta stream for a staged channel.
+
+        Ticks once per affected record as stagings are created, added to, removed from and released, so a
+        module can react to what is being staged -- for example to build a derived staging on another
+        channel, and to release or remove it when the upstream staging is.
+        """
+        if field not in self._stage_events:
+            raise NoProviderException(f"No staging enabled for channel: {field}")
+        return self._stage_events[field].out()
+
+    def add_stage_listener(self, field: str, listener: Any) -> None:
+        """Call ``listener(events)`` whenever ``field``'s staging areas change.
+
+        The callback counterpart of :meth:`get_stage_events`, for observers that are not part of the
+        graph. Stages declared by annotation are wired during finalization, after every module's
+        ``connect``, so a listener -- unlike a graph edge -- can be attached from a later hook.
+        """
+        if field not in self._stages:
+            raise NoProviderException(f"No staging enabled for channel: {field}")
+        self._stages[field].add_listener(listener)
+
+    def set_stage_requests(self, field: str, requests: Any) -> None:
+        """Drive a staged channel from a ``ts[StagingRequest]``.
+
+        The graph-native counterpart to calling ``stage_add``/``stage_remove``/``stage_release``
+        directly: each tick is applied to ``field``'s staging areas.
+        """
+        if field not in self._stages:
+            raise NoProviderException(f"No staging enabled for channel: {field}")
+        apply_stage_requests(requests, self, field)
 
     def staged_channels(self) -> list[str]:
         """Return list of channel names that have staging enabled."""
@@ -1219,7 +1255,7 @@ class Channels(BaseModel, metaclass=ChannelsMetaclass):
     ) -> list[str]:
         """Add a struct to staging area(s) for a channel.
 
-        See STAGE.md for full semantics.
+        See docs/wiki/Staging.md for full semantics.
         """
         if field not in self._stages:
             raise NoProviderException(f"No staging enabled for channel: {field}")
@@ -1233,7 +1269,7 @@ class Channels(BaseModel, metaclass=ChannelsMetaclass):
     ) -> list[str]:
         """Remove struct(s) from staging area(s).
 
-        See STAGE.md for full semantics.
+        See docs/wiki/Staging.md for full semantics.
         """
         if field not in self._stages:
             raise NoProviderException(f"No staging enabled for channel: {field}")
@@ -1270,7 +1306,7 @@ class Channels(BaseModel, metaclass=ChannelsMetaclass):
     ) -> list[str]:
         """List staging IDs for a channel.
 
-        See STAGE.md for full semantics.
+        See docs/wiki/Staging.md for full semantics.
         """
         if field not in self._stages:
             raise NoProviderException(f"No staging enabled for channel: {field}")

--- a/csp_gateway/server/gateway/csp/stage.py
+++ b/csp_gateway/server/gateway/csp/stage.py
@@ -4,11 +4,15 @@ A channel with staging enabled accumulates structs into named "staging areas"
 before they are released into the main channel. This allows batch preparation
 and atomic release of groups of structs.
 
-See STAGE.md for the full API specification.
+Staging mutations are also published as a ``ts[StagingEvent]`` delta stream, so modules can react to
+what is being staged (see ``GatewayChannels.get_stage_events``).
 """
 
 import threading
+from collections.abc import Callable
 
+import csp
+from csp import Enum, ts
 from csp.impl.genericpushadapter import GenericPushAdapter
 
 from csp_gateway.utils import GatewayStruct
@@ -16,8 +20,73 @@ from csp_gateway.utils import GatewayStruct
 __all__ = (
     "Stage",
     "Staging",
+    "StagingAction",
+    "StagingEvent",
+    "StagingRequest",
+    "apply_stage_requests",
     "build_staging_node",
 )
+
+
+class StagingAction(Enum):
+    """What happened to a staging area, one action per affected record."""
+
+    CREATED = 0
+    ADDED = 1
+    REMOVED = 2
+    RELEASED = 3
+
+
+class StagingEvent(GatewayStruct):
+    """One staging mutation, as ticked on a channel's staging event stream.
+
+    ``CREATED`` and a whole-staging ``REMOVED`` carry no items; ``ADDED``/``REMOVED`` carry the single
+    record involved, and ``RELEASED`` carries everything the staging released.
+
+    ``items`` uses ``list`` (untyped) for the same reason ``Staging.items`` does.
+    """
+
+    channel: str = ""
+    staging_id: str = ""
+    action: StagingAction = StagingAction.CREATED
+    items: list = []
+
+
+class StagingRequest(GatewayStruct):
+    """A request to mutate a staging area, tickable by a module.
+
+    The same actions the REST API exposes: ``CREATED`` opens an empty staging, ``ADDED``/``REMOVED``
+    stage or unstage each of ``items``, and ``RELEASED`` releases. A ``REMOVED`` with no ``items``
+    clears rather than unstaging a particular record.
+
+    Leaving ``staging_ids`` unset means "no ids" (the API's ``None``: latest, or a new staging); setting
+    it to an empty list means "all" -- the same distinction the REST layer draws.
+    """
+
+    action: StagingAction = StagingAction.ADDED
+    staging_ids: list = []
+    items: list = []
+
+
+@csp.node
+def apply_stage_requests(requests: ts[StagingRequest], channels: object, field: str) -> None:
+    """Apply ticked staging requests to ``field``'s staging areas."""
+    if csp.ticked(requests):
+        # Unset means None (latest / new); an explicit empty list means all.
+        staging_ids = requests.staging_ids if hasattr(requests, "staging_ids") else None
+        if requests.action == StagingAction.RELEASED:
+            channels.stage_release(field, staging_ids=staging_ids)
+        elif requests.action == StagingAction.CREATED:
+            channels.stage_add(field, None, staging_ids=staging_ids)
+        elif requests.action == StagingAction.ADDED:
+            for item in requests.items:
+                channels.stage_add(field, item, staging_ids=staging_ids)
+        elif requests.action == StagingAction.REMOVED:
+            if requests.items:
+                for item in requests.items:
+                    channels.stage_remove(field, item, staging_ids=staging_ids)
+            else:
+                channels.stage_remove(field, None, staging_ids=staging_ids)
 
 
 class Stage:
@@ -75,13 +144,60 @@ class Staging(GatewayStruct):
 class _StageManager:
     """Manages multiple staging areas for a single channel.
 
-    Thread-safe: all mutations are guarded by a lock.
+    Thread-safe: all mutations are guarded by a lock. Mutations are reported to ``on_event`` as a list
+    of ``(action, staging_id, items)`` deltas, derived by diffing the areas around each operation so
+    the branchy add/remove semantics only have to be expressed once.
     """
 
-    def __init__(self):
-        self._lock = threading.Lock()
+    def __init__(self, on_event: Callable[[list], None] | None = None):
+        # Reentrant so the public wrappers can snapshot/diff around the locked implementations.
+        self._lock = threading.RLock()
         self._areas: dict[str, Staging] = {}
-        self._released: dict[str, Staging] = {}
+        self._on_event = on_event
+        self._listeners: list[Callable[[list], None]] = []
+
+    def add_listener(self, listener: Callable[[list], None]) -> None:
+        """Also report deltas to ``listener``.
+
+        Unlike ``on_event`` -- which feeds the graph's event adapter and so must be set while the graph is
+        built -- listeners may be attached at any point, including after the graph is finalized.
+        """
+        self._listeners.append(listener)
+
+    def _snapshot(self) -> dict[str, list]:
+        """The current areas as ``staging_id -> items``. Call under the lock."""
+        return {sid: area.items[:] for sid, area in self._areas.items()}
+
+    def _diff(self, before: dict[str, list]) -> list:
+        """Deltas between ``before`` and the current areas. Call under the lock.
+
+        A staging that vanished is reported as a removal of each of its records followed by a removal of
+        the staging itself. Releases do not go through here -- they are reported explicitly.
+        """
+        events = []
+        after = self._snapshot()
+        for sid, items in after.items():
+            previous = before.get(sid)
+            if previous is None:
+                events.append((StagingAction.CREATED, sid, []))
+                previous = []
+            previous_ids = {item.id for item in previous}
+            current_ids = {item.id for item in items}
+            events.extend((StagingAction.ADDED, sid, [item]) for item in items if item.id not in previous_ids)
+            events.extend((StagingAction.REMOVED, sid, [item]) for item in previous if item.id not in current_ids)
+        for sid, items in before.items():
+            if sid not in after:
+                events.extend((StagingAction.REMOVED, sid, [item]) for item in items)
+                events.append((StagingAction.REMOVED, sid, []))
+        return events
+
+    def _emit(self, events: list) -> None:
+        if not events:
+            return
+        if self._on_event is not None:
+            self._on_event(events)
+        for listener in self._listeners:
+            listener(events)
 
     @property
     def staging_ids(self) -> list[str]:
@@ -93,10 +209,55 @@ class _StageManager:
         struct: GatewayStruct | None = None,
         staging_ids: list[str] | None = None,
     ) -> list[str]:
+        """Add a struct to staging area(s), reporting what changed.
+
+        Returns the list of staging IDs affected.
+        """
+        with self._lock:
+            before = self._snapshot()
+            affected = self._stage_add(struct, staging_ids)
+            events = self._diff(before)
+        self._emit(events)
+        return affected
+
+    def stage_remove(
+        self,
+        struct: GatewayStruct | None = None,
+        staging_ids: list[str] | None = None,
+    ) -> list[str]:
+        """Remove struct(s) from staging area(s), reporting what changed.
+
+        Returns the list of staging IDs affected.
+        """
+        with self._lock:
+            before = self._snapshot()
+            affected = self._stage_remove(struct, staging_ids)
+            events = self._diff(before)
+        self._emit(events)
+        return affected
+
+    def stage_release(
+        self,
+        staging_ids: list[str] | None = None,
+    ) -> dict[str, list[GatewayStruct]]:
+        """Release staged structs, reporting one RELEASED event per staging.
+
+        Returns a dict mapping staging_id -> list of released structs.
+        """
+        with self._lock:
+            released = self._stage_release(staging_ids)
+        self._emit([(StagingAction.RELEASED, sid, items) for sid, items in released.items()])
+        return released
+
+    def _stage_add(
+        self,
+        struct: GatewayStruct | None = None,
+        staging_ids: list[str] | None = None,
+    ) -> list[str]:
         """Add a struct to staging area(s).
 
         Returns the list of staging IDs affected.
-        See STAGE.md for the full semantics.
+        See docs/wiki/Staging.md for the full semantics.
         """
         with self._lock:
             if struct is None and staging_ids is not None and len(staging_ids) > 0:
@@ -152,7 +313,7 @@ class _StageManager:
                 affected.append(sid)
             return affected
 
-    def stage_remove(
+    def _stage_remove(
         self,
         struct: GatewayStruct | None = None,
         staging_ids: list[str] | None = None,
@@ -160,7 +321,7 @@ class _StageManager:
         """Remove struct(s) from staging area(s).
 
         Returns the list of staging IDs affected.
-        See STAGE.md for the full semantics.
+        See docs/wiki/Staging.md for the full semantics.
         """
         with self._lock:
             if struct is None and staging_ids is not None and len(staging_ids) == 0:
@@ -208,14 +369,14 @@ class _StageManager:
                     affected.append(sid)
             return affected
 
-    def stage_release(
+    def _stage_release(
         self,
         staging_ids: list[str] | None = None,
     ) -> dict[str, list[GatewayStruct]]:
         """Release staged structs.
 
-        Returns a dict mapping staging_id -> list of released structs.
-        Released stagings are moved to the released archive.
+        Returns a dict mapping staging_id -> list of released structs. A released staging is dropped;
+        its contents ride the RELEASED event and the channel itself.
         """
         with self._lock:
             if staging_ids is None:
@@ -223,7 +384,6 @@ class _StageManager:
                 released = {}
                 for sid, area in list(self._areas.items()):
                     released[sid] = area.items[:]
-                    self._released[sid] = area
                 self._areas.clear()
                 return released
 
@@ -231,7 +391,6 @@ class _StageManager:
             for sid in staging_ids:
                 if sid in self._areas:
                     released[sid] = self._areas[sid].items[:]
-                    self._released[sid] = self._areas[sid]
                     del self._areas[sid]
             return released
 
@@ -251,29 +410,33 @@ class _StageManager:
         self,
         staging_id: str | None = None,
     ) -> dict[str, list[GatewayStruct]]:
-        """Look up contents of staging area(s), including released stages.
+        """Look up contents of pending staging area(s).
 
-        Returns dict mapping staging_id -> list of structs.
+        Returns dict mapping staging_id -> list of structs. Released stagings are gone; their contents
+        were delivered on the channel and on the RELEASED event.
         """
         with self._lock:
             if staging_id is None:
-                result = {sid: area.lookup() for sid, area in self._areas.items()}
-                result.update({sid: area.lookup() for sid, area in self._released.items()})
-                return result
+                return {sid: area.lookup() for sid, area in self._areas.items()}
             if staging_id in self._areas:
                 return {staging_id: self._areas[staging_id].lookup()}
-            if staging_id in self._released:
-                return {staging_id: self._released[staging_id].lookup()}
             return {}
 
 
-def build_staging_node(element_type: type) -> tuple:
-    """Build a _StageManager instance and its associated push adapter for releases.
+def build_staging_node(element_type: type, channel: str = "") -> tuple:
+    """Build a _StageManager and the push adapters that carry its output into the graph.
 
-    Returns (stage, push_adapter) where:
+    Returns (stage, push_adapter, event_adapter) where:
     - stage: the _StageManager instance for managing staging areas
     - push_adapter: GenericPushAdapter[element_type] to push released items into the graph
+    - event_adapter: GenericPushAdapter[StagingEvent] carrying the staging delta stream
     """
-    stage = _StageManager()
+    event_adapter = GenericPushAdapter(StagingEvent, name=f"StagingEvents<{element_type.__name__}>")
+
+    def _on_event(events: list) -> None:
+        for action, staging_id, items in events:
+            event_adapter.push_tick(StagingEvent(channel=channel, staging_id=staging_id, action=action, items=items))
+
+    stage = _StageManager(on_event=_on_event)
     push_adapter = GenericPushAdapter(element_type, name=f"StagingRelease<{element_type.__name__}>")
-    return stage, push_adapter
+    return stage, push_adapter, event_adapter

--- a/csp_gateway/server/modules/web/__init__.py
+++ b/csp_gateway/server/modules/web/__init__.py
@@ -4,4 +4,5 @@ from .mount_fields import MountFieldRestRoutes
 from .outputs import MountOutputsFolder
 from .perspective import *
 from .send_form import MountSendForm
+from .staging_panel import MountStagingPanel
 from .websocket import MountWebSocketRoutes

--- a/csp_gateway/server/modules/web/send_form.py
+++ b/csp_gateway/server/modules/web/send_form.py
@@ -92,7 +92,7 @@ class MountSendForm(GatewayModule):
             )
 
         if forms:
-            app.add(Region.DRAWER_BOTTOM, app.send_panel(forms))
+            app.add(Region.DRAWER_BOTTOM, app.send_panel(forms), label="Send data to channel")
             seeds: dict[str, Any] = {"send_channel": forms[0].channel}
             for spec in forms:
                 if spec.keys:

--- a/csp_gateway/server/modules/web/staging_panel.py
+++ b/csp_gateway/server/modules/web/staging_panel.py
@@ -1,0 +1,263 @@
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
+
+from csp_gateway.server import ChannelSelection, GatewayChannels, GatewayModule
+
+# separate to avoid circular
+from csp_gateway.server.web import GatewayWebApp
+
+if TYPE_CHECKING:
+    from csp_gateway.server.web.spaday_ui import GatewayUI
+
+#: The namespace the panel's state rides under on the UI's transports wire.
+NAMESPACE = "staging"
+
+
+class StagingCell(BaseModel):
+    """One record field, rendered as a table cell."""
+
+    id: str
+    value: str
+
+
+class StagingRecord(BaseModel):
+    """One staged record."""
+
+    id: str
+    cells: list[StagingCell] = []
+
+
+class StagingColumn(BaseModel):
+    """One table column, keyed by the struct field it shows."""
+
+    id: str
+
+
+class StagingArea(BaseModel):
+    """One pending staging area on one channel."""
+
+    id: str
+    channel: str
+    url: str
+    summary: str
+    overflow: str = ""
+    columns: list[StagingColumn] = []
+    records: list[StagingRecord] = []
+
+
+class StagingState(BaseModel):
+    """Every pending staging the viewer is allowed to see.
+
+    ``empty`` and ``staged`` are complements, published rather than derived so each branch of the panel
+    binds a plain field.
+    """
+
+    empty: bool = True
+    staged: bool = False
+    areas: list[StagingArea] = []
+
+
+class MountStagingPanel(GatewayModule):
+    """Spaday UI: a live "Staged data" tab, with per-record removal and per-staging release.
+
+    This is a **presentation** module for the spaday UI provider only -- its `ui()` hook is a no-op under
+    the default (React) UI, and it mounts no routes (it relies on the stage endpoints that
+    `MountRestRoutes` provides). It shares the bottom drawer (the header's `+`) with the send form.
+    Each staged channel contributes one block per staging area: a table with a column per struct field and
+    a row per staged record, each row ending in an X that `DELETE`s just that record, plus a button that
+    `PATCH`es the whole staging into the channel.
+
+    The tree is reactive: it subscribes to each channel's `StagingEvent` stream and republishes the
+    staging snapshot over the UI's transports wire, so stagings and records appear and disappear as they
+    are staged and released, without a page reload.
+    """
+
+    mount_staging: ChannelSelection = Field(
+        default_factory=ChannelSelection,
+        description=(
+            "Staged channels to render a panel for. Should match the channels `MountRestRoutes` actually "
+            "mounts stage routes for, so the UI never shows a control that calls a route that was "
+            "intentionally not mounted. Defaults to every channel with staging enabled."
+        ),
+    )
+
+    max_records: int = Field(
+        default=50,
+        description=(
+            "Maximum records rendered per staging area. Staging areas are prepared by hand and are "
+            "expected to be small; this only bounds the payload for a runaway staging."
+        ),
+    )
+
+    excluded_columns: list[str] = Field(
+        default_factory=lambda: ["id", "timestamp"],
+        description="Struct fields omitted from the table's columns.",
+    )
+
+    # GatewayModule is a pydantic model, so the runtime handles need declared fields to live on.
+    handle: Any = None
+    channels: Any = None
+    app: Any = None
+
+    def connect(self, channels: GatewayChannels) -> None:
+        self.channels = channels
+
+    def rest(self, app: GatewayWebApp) -> None:
+        # NO-OP: no REST routes; the panel calls the stage routes mounted by MountRestRoutes.
+        ...
+
+    def ui(self, app: "GatewayUI") -> None:
+        from csp_gateway.server.web.spaday_ui import Region
+
+        self.app = app
+        self.handle = app.model(NAMESPACE, StagingState)
+        # Listeners attach here rather than in `connect`, because stages declared by annotation are not
+        # wired until the graph is finalized -- after every module's `connect` has run.
+        for channel in self._selected(self.channels):
+            self.channels.add_stage_listener(channel, self._on_stage_event)
+        app.add(Region.DRAWER_BOTTOM, self._panel(), order=50, label="Staged data")
+        self.republish()
+
+    def _on_stage_event(self, events: list) -> None:
+        self.republish()
+
+    def republish(self) -> None:
+        """Send the current staging snapshot to every connected viewer."""
+        if self.handle is not None:
+            self.handle.publish(self._snapshot())
+
+    def _selected(self, channels: GatewayChannels) -> list[str]:
+        allowed = set(self.mount_staging.select_from(channels))
+        return [channel for channel in channels.staged_channels() if channel in allowed]
+
+    def _snapshot(self) -> "StagingState":
+        """The pending stagings, flattened into the shape the reactive tree renders."""
+        channels = self.channels
+        areas = []
+        for channel in self._selected(channels):
+            # `stage_list` is the pending-only view; `stage_lookup` alone would keep reporting stagings
+            # that have already been released.
+            for staging_id in channels.stage_list(channel):
+                records = channels.stage_lookup(channel, staging_id).get(staging_id, [])
+                shown = records[: self.max_records]
+                columns = self._columns(shown)
+                areas.append(
+                    StagingArea(
+                        id=f"{channel}:{staging_id}",
+                        channel=channel,
+                        url=self._stage_url(channel, staging_id),
+                        summary=f"{len(records)} staged",
+                        overflow=f"+{len(records) - self.max_records} more" if len(records) > self.max_records else "",
+                        columns=[StagingColumn(id=name) for name in columns],
+                        records=[
+                            StagingRecord(
+                                id=record.id,
+                                cells=[StagingCell(id=name, value=self._cell_text(record, name)) for name in columns],
+                            )
+                            for record in shown
+                        ],
+                    )
+                )
+        return StagingState(empty=not areas, staged=bool(areas), areas=areas)
+
+    def _columns(self, records: list) -> list[str]:
+        """The struct fields to show, in declaration order, skipping ones no record has set."""
+        excluded = set(self.excluded_columns)
+        if not records:
+            return []
+        return [name for name in type(records[0]).metadata() if name not in excluded and any(hasattr(r, name) for r in records)]
+
+    def _cell_text(self, record: Any, name: str) -> str:
+        value = getattr(record, name, None)
+        return "" if value is None else str(value)
+
+    def _stage_url(self, channel: str, staging_id: str) -> str:
+        return self.app.url(f"{self.app.web_app.settings.API_STR}/stage/{channel}?id={staging_id}")
+
+    def _panel(self) -> Any:
+        """The reactive tree: an empty-state callout, or one block per pending staging area."""
+        from spaday.actions import field
+        from spaday.components.shell import Column, Each, Show
+        from spaday_webawesome import WaCallout
+
+        return Column(
+            Show(WaCallout().text("Nothing staged."), when=field(f"{NAMESPACE}.empty")),
+            Show(
+                Each(self._area_block(), field=f"{NAMESPACE}.areas", key="id", scope="area"),
+                when=field(f"{NAMESPACE}.staged"),
+            ),
+            gap="0.75rem",
+        ).style(padding="0.5rem")
+
+    def _area_block(self) -> Any:
+        """One staging area: a header, its record table, and the button that releases the whole thing."""
+        from spaday import element
+        from spaday.actions import CallEndpoint, item
+        from spaday.components.shell import Column, Each, Row
+        from spaday_webawesome import WaButton
+
+        header = (
+            Row(justify="space-between", gap="0.5rem")
+            .child(element("strong").compute("textContent", item("channel")))
+            .child(element("small").compute("textContent", item("summary")).style(opacity="0.7"))
+        )
+        table = element(
+            "table",
+            element("thead", element("tr", Each(self._header_cell(), items=item("columns"), key="id"), self._header_cell(blank=True))),
+            element("tbody", Each(self._record_row(), items=item("records"), key="id", scope="record")),
+        ).style(width="100%", border_collapse="collapse", font_size="0.8rem")
+        # Struct fields are unbounded in number, so the table scrolls rather than squeezing its columns.
+        scroller = element("div", table).style(overflow_x="auto")
+        overflow = element("small").compute("textContent", item("overflow")).style(opacity="0.7")
+        release = WaButton(variant="brand").text("Submit staging").style(width="100%").on("click", CallEndpoint("PATCH", item("url")))
+
+        return Column(header, scroller, overflow, release, gap="0.4rem").style(
+            border="1px solid var(--spa-border)", border_radius="6px", padding="0.5rem"
+        )
+
+    def _header_cell(self, blank: bool = False) -> Any:
+        from spaday import element
+        from spaday.actions import item
+
+        cell = element("th").style(
+            text_align="left",
+            font_weight="600",
+            opacity="0.7",
+            white_space="nowrap",
+            padding="0.15rem 0.4rem 0.25rem 0",
+            border_bottom="1px solid var(--spa-border)",
+        )
+        # The trailing column heads the X buttons, so it has no label to bind.
+        return cell if blank else cell.compute("textContent", item("id"))
+
+    def _record_row(self) -> Any:
+        """One staged record: a cell per column and an X that removes just that record."""
+        from spaday import element
+        from spaday.actions import CallEndpoint, item, obj, scope
+        from spaday.components.shell import Each
+        from spaday_webawesome import WaButton
+
+        # `Staging.remove` matches on id, so the id alone identifies the record to drop.
+        remove = (
+            WaButton(appearance="plain", variant="danger")
+            .text("\u00d7")
+            .on("click", CallEndpoint("DELETE", scope("area.url"), obj({"id": scope("record.id")})))
+        )
+        cell = (
+            element("td")
+            .compute("textContent", item("value"))
+            .style(
+                white_space="nowrap",
+                padding="0.2rem 0.4rem 0.2rem 0",
+                border_bottom="1px solid var(--spa-border)",
+                max_width="30ch",
+                overflow="hidden",
+                text_overflow="ellipsis",
+            )
+        )
+        return element(
+            "tr",
+            Each(cell, items=item("cells"), key="id"),
+            element("td", remove).style(text_align="right", padding="0"),
+        )

--- a/csp_gateway/server/web/routes/stage.py
+++ b/csp_gateway/server/web/routes/stage.py
@@ -3,7 +3,7 @@
 Exposes endpoints under ``/api/v1/stage/`` for managing staged structs
 on channels that have staging enabled.
 
-See STAGE.md for the full API specification.
+See docs/wiki/Staging.md for the full API specification.
 """
 
 import json

--- a/csp_gateway/server/web/spaday_ui.py
+++ b/csp_gateway/server/web/spaday_ui.py
@@ -14,14 +14,17 @@ the optional `spaday` extra (`pip install 'csp-gateway[spaday]'`).
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 from dataclasses import dataclass, field as _dc_field
 from typing import TYPE_CHECKING, Any
 
 from pydantic import TypeAdapter
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.routing import Mount
+from starlette.routing import Mount, WebSocketRoute
+from starlette.websockets import WebSocket
 
 try:
     import spaday  # noqa: F401
@@ -48,10 +51,11 @@ from spaday.actions import (
     obj,
 )
 from spaday.backends.starlette import mount as _spaday_mount
-from spaday.components.form import FormField, form
-from spaday.components.perspective import PerspectivePanel
 from spaday.components.shell import AppShell, Column, Region, Row, Show
-from spaday.components.webawesome import (
+from spaday_perspective import PerspectivePanel
+from spaday_webawesome import (
+    FormField,
+    Tabs,
     WaButton,
     WaCallout,
     WaDialog,
@@ -59,6 +63,7 @@ from spaday.components.webawesome import (
     WaIcon,
     WaOption,
     WaSelect,
+    form,
 )
 
 if TYPE_CHECKING:
@@ -69,6 +74,11 @@ __all__ = (
     "Region",
     "SendSpec",
 )
+
+log = logging.getLogger(__name__)
+
+# The tenant every connection shares when no auth middleware can identify it.
+_ANONYMOUS_TENANT = "__anonymous__"
 
 
 # Minimal shell theming so the spaday page looks reasonable in both light and dark modes.
@@ -107,6 +117,36 @@ class _Contribution:
 
     component: Any
     order: int = 0
+    label: str | None = None
+
+
+class ModelHandle:
+    """A module's live UI state: one transports model, mirrored per authenticated tenant.
+
+    Obtained from `GatewayUI.model()` in a module's `ui()` hook, which runs once at startup, and used
+    afterwards to push updates from wherever the state actually changes -- a csp node, a REST handler.
+
+    `publish` is safe to call from any thread. Values are computed per tenant, so a deployment running
+    `AuthFilterMiddleware` keeps its per-identity filtering: pass a callable to derive each tenant's
+    view of the state from its identity, or a plain value when every tenant may see the same thing.
+    """
+
+    def __init__(self, ui: GatewayUI, namespace: str, model: Any) -> None:
+        self._ui = ui
+        self._namespace = namespace
+        self._model = model
+
+    @property
+    def namespace(self) -> str:
+        return self._namespace
+
+    def publish(self, value: Any) -> None:
+        """Push new state to every connected tenant.
+
+        ``value`` is either the state itself, or a callable taking a tenant's identity (``None`` when
+        unauthenticated) and returning that tenant's view of it.
+        """
+        self._ui._publish(self._namespace, value)
 
 
 class GatewayUI:
@@ -122,6 +162,33 @@ class GatewayUI:
         self._settings = settings
         self._regions: dict[Region, list[_Contribution]] = {}
         self._store_seeds: dict[str, Any] = {}
+        # Live UI state: namespace -> (model, latest value factory). The hub and its models only exist
+        # once a module declares one, so a gateway with no live state serves no websocket.
+        self._models: dict[str, Any] = {}
+        self._latest: dict[str, Any] = {}
+        self._tenant_models: dict[Any, dict[str, tuple]] = {}
+        self._tenant_identity: dict[Any, Any] = {}
+        self._hub: Any = None
+        self._loop: Any = None
+        self._autosync: Any = None
+
+    def model(self, namespace: str, model: Any) -> ModelHandle:
+        """Declare live UI state this module publishes, mirrored into the page's signal store.
+
+        `ui()` runs once at startup, so a module declares its state here and pushes to the returned
+        handle later. Fields arrive in the browser under ``<namespace>.``, so several modules can
+        publish without colliding, and a component binds to them like any other state::
+
+            self._staging = app.model("staging", StagingView)
+            app.add(Region.GUTTER_RIGHT, Table().compute("rows", field("staging.rows")))
+
+        Each authenticated identity gets its own copy of the model, so what one user is shown is never
+        broadcast to another.
+        """
+        if namespace in self._models:
+            raise ValueError(f"UI model namespace already declared: {namespace}")
+        self._models[namespace] = model
+        return ModelHandle(self, namespace, model)
 
     @property
     def settings(self) -> Any:
@@ -131,7 +198,7 @@ class GatewayUI:
     def web_app(self) -> GatewayWebApp:
         return self._web_app
 
-    def add(self, region: Region, component: Any, *, order: int = 0) -> None:
+    def add(self, region: Region, component: Any, *, order: int = 0, label: str | None = None) -> None:
         """Inject a spaday `component` into a named shell `region`.
 
         This is the single contribution API. Multiple contributions to the same region render
@@ -140,8 +207,16 @@ class GatewayUI:
         contributions slot in around them predictably. Build the component with one of the
         helpers (`perspective_panel`, `layout_selector`, `send_panel`, `link_button`,
         `post_button`, `confirm_button`) or hand-author any spaday component.
+
+        `component` may also be a zero-argument callable returning one. Module `ui()` hooks run
+        once at startup, so a callable is the way to render server-side state that changes after
+        that (it is re-invoked on each page build, i.e. per page load).
+
+        `label` names the contribution for regions that present their panels as tabs (the bottom
+        drawer). It is ignored elsewhere, and the drawer only tabs when every panel in it is
+        labelled -- otherwise an unlabelled panel would get a blank tab.
         """
-        self._regions.setdefault(Region(region), []).append(_Contribution(component=component, order=order))
+        self._regions.setdefault(Region(region), []).append(_Contribution(component=component, order=order, label=label))
 
     def seed_store(self, **fields: Any) -> None:
         """Seed initial values into the page's reactive signal store (merged across callers)."""
@@ -164,12 +239,21 @@ class GatewayUI:
 
         ``builtin`` is a list of ``(order, component)`` pairs for the provider's own default
         pieces; they are merged with the module contributions and sorted by order. ``None``
-        components (e.g. an omitted optional logo) are dropped.
+        components (e.g. an omitted optional logo) are dropped. A contribution may be a zero-arg
+        callable, resolved here so it re-renders from current server state on every page build.
         """
         items: list[tuple] = [(o, c) for (o, c) in builtin if c is not None]
         items += [(c.order, c.component) for c in self._regions.get(region, []) if c.component is not None]
         items.sort(key=lambda t: t[0])
-        return [c for _, c in items]
+        resolved = [c() if callable(c) else c for _, c in items]
+        return [c for c in resolved if c is not None]
+
+    def _labeled_region(self, region: Region) -> list[tuple[str | None, Any]]:
+        """The composed components for a region, each paired with its contribution's tab label."""
+        items = [(c.order, c.label, c.component) for c in self._regions.get(region, []) if c.component is not None]
+        items.sort(key=lambda t: t[0])
+        labeled = [(label, component() if callable(component) else component) for _, label, component in items]
+        return [(label, component) for label, component in labeled if component is not None]
 
     def perspective_panel(
         self,
@@ -416,7 +500,11 @@ class GatewayUI:
 
         # Compose region contents (built-in chrome merged with module contributions, order-sorted).
         right_drawer_items = self._region(Region.DRAWER_RIGHT, (100, email_button))
-        bottom_drawer_items = self._region(Region.DRAWER_BOTTOM)
+        bottom_drawer_panels = self._labeled_region(Region.DRAWER_BOTTOM)
+        bottom_drawer_items = [component for _, component in bottom_drawer_panels]
+        # Several labelled panels share the drawer, so they become tabs rather than a tall stack.
+        bottom_tabbed = len(bottom_drawer_panels) > 1 and all(label for label, _ in bottom_drawer_panels)
+        bottom_label = "Channel data" if bottom_tabbed else "Send data to a channel"
         gutter_left = self._region(Region.GUTTER_LEFT)
         gutter_right = self._region(Region.GUTTER_RIGHT)
         main_items = self._region(Region.MAIN)
@@ -429,9 +517,7 @@ class GatewayUI:
             else None
         )
         plus_button = (
-            WaButton(appearance="plain", title="Send data to a channel")
-            .on("click", Toggle(by_id(bottom_drawer_id), "open"))
-            .child(WaIcon(name="plus"))
+            WaButton(appearance="plain", title=bottom_label).on("click", Toggle(by_id(bottom_drawer_id), "open")).child(WaIcon(name="plus"))
             if bottom_drawer_items
             else None
         )
@@ -482,17 +568,117 @@ class GatewayUI:
                 .child(Column(*right_drawer_items, gap="0.6rem")),
             )
         if bottom_drawer_items:
+            if bottom_tabbed:
+                tabs = Tabs()
+                for label, component in bottom_drawer_panels:
+                    tabs.tab(label, component)
+                bottom_body: Any = tabs
+            else:
+                bottom_body = Column(*bottom_drawer_items, gap="1rem")
             shell.add(
                 Region.DRAWER_BOTTOM,
-                WaDrawer(label="Send data to a channel", placement="bottom", light_dismiss=True)
-                .prop("id", bottom_drawer_id)
-                .css(size="70vh")
-                .child(Column(*bottom_drawer_items, gap="1rem")),
+                WaDrawer(label=bottom_label, placement="bottom", light_dismiss=True).prop("id", bottom_drawer_id).css(size="70vh").child(bottom_body),
             )
         if overlay_items:
             shell.add(Region.OVERLAY, *overlay_items)
 
         return shell.build().style(height="100vh").bind_root_class("wa-dark", "dark")
+
+    @property
+    def _auth_filter(self) -> Any:
+        """The configured `AuthFilterMiddleware`, if any -- the same one the REST and websocket paths use."""
+        return getattr(self._web_app.app.state, "auth_filter_middleware", None)
+
+    async def _tenant_for(self, websocket: Any) -> tuple[Any, Any]:
+        """The ``(tenant key, identity)`` a connection belongs to.
+
+        Identity resolution is async (an external validator may do I/O), which is why it happens here
+        rather than in the hub's key function -- that one is called synchronously.
+        """
+        auth_filter = self._auth_filter
+        if auth_filter is None:
+            return _ANONYMOUS_TENANT, None
+        try:
+            identity = await auth_filter.get_identity_from_websocket(websocket)
+        except Exception:
+            log.exception("Failed to resolve UI websocket identity; serving the anonymous tenant")
+            return _ANONYMOUS_TENANT, None
+        if not identity:
+            return _ANONYMOUS_TENANT, None
+        return json.dumps(identity, sort_keys=True, default=str), identity
+
+    def _view_for(self, namespace: str, identity: Any) -> Any:
+        """One tenant's view of a namespace's latest published state."""
+        value = self._latest.get(namespace)
+        return value(identity) if callable(value) else value
+
+    def _apply(self, target: Any, value: Any) -> None:
+        """Copy a published value onto a tenant's hosted model instance."""
+        if value is None:
+            return
+        fields = value if isinstance(value, dict) else getattr(value, "__dict__", {})
+        for name, field_value in fields.items():
+            setattr(target, name, field_value)
+
+    def _host_tenant(self, tenant: Any, identity: Any) -> None:
+        """Give a tenant its own instance of every declared model, seeded with current state."""
+        if tenant in self._tenant_models:
+            return
+        session = self._hub.tenant(tenant)
+        hosted: dict[str, tuple] = {}
+        for namespace, model in self._models.items():
+            instance = model()
+            self._apply(instance, self._view_for(namespace, identity))
+            hosted[namespace] = (instance, session.host(instance))
+        self._tenant_models[tenant] = hosted
+        self._tenant_identity[tenant] = identity
+
+    def _publish(self, namespace: str, value: Any) -> None:
+        """Push new state for a namespace to every connected tenant, from any thread."""
+        self._latest[namespace] = value
+        if self._hub is None:
+            return
+
+        # Apply to each tenant's model here, so state is correct even before a loop exists; only the
+        # emit needs to be marshalled onto the server loop.
+        updates = []
+        for tenant, hosted in self._tenant_models.items():
+            entry = hosted.get(namespace)
+            if entry is None:
+                continue
+            instance, mid = entry
+            self._apply(instance, self._view_for(namespace, self._tenant_identity.get(tenant)))
+            updates.append((tenant, mid))
+
+        loop = self._loop
+        if not updates or loop is None or not loop.is_running():
+            return
+
+        def _emit() -> None:
+            for tenant, mid in updates:
+                self._hub.tenant(tenant).update(mid)
+
+        loop.call_soon_threadsafe(_emit)
+
+    def _ws_endpoint(self) -> Any:
+        """The websocket serving the hub, with each connection routed to its authenticated tenant."""
+        import transports
+
+        self._hub = transports.Hub(key=lambda conn: getattr(conn.state, "csp_gateway_tenant", _ANONYMOUS_TENANT))
+        inner = transports.ws_endpoint(self._hub)
+
+        # Annotated, not `Any`: FastAPI resolves the signature and would treat an unrecognised
+        # annotation as a required query parameter, rejecting every connection with a 1008.
+        async def endpoint(websocket: WebSocket) -> None:
+            tenant, identity = await self._tenant_for(websocket)
+            websocket.state.csp_gateway_tenant = tenant
+            self._loop = asyncio.get_running_loop()
+            self._host_tenant(tenant, identity)
+            if self._autosync is None:
+                self._autosync = asyncio.create_task(transports.autosync(self._hub))
+            await inner(websocket)
+
+        return endpoint
 
     def mount(self) -> None:
         """Build the spaday page and register its routes on the gateway app.
@@ -512,10 +698,26 @@ class GatewayUI:
         # like every other gateway route. The dynamic page/tree go on the authenticated app router; the
         # static /js mount stays public, like other UI assets.
         scratch = Starlette()
+        # Only wire a transports model when a module actually declared live state; otherwise the page is a
+        # static tree and no websocket is served.
+        wire: Any = None
+        routes: list = []
+        if self._models:
+            from spaday import Wire
+
+            wire = [Wire("/ws", namespace=namespace) for namespace in self._models]
+            routes = [WebSocketRoute("/ws", self._ws_endpoint())]
         _spaday_mount(
             scratch,
             self.build_page,
-            bundles=["webawesome", "perspective"],
+            # Component libraries ship as their own distributions and are resolved by entry point.
+            packages=["webawesome", "perspective"],
+            # spaday infers "source checkout" from a `js/` dir next to itself, which any distribution
+            # shipping a top-level `js/` package (plotly does) satisfies -- serving assets we consume
+            # from the wheel, never from a spaday checkout.
+            layout="installed",
+            wire=wire,
+            routes=routes,
             store={"dark": False, **self._store_seeds},
             head=THEME_CSS,
             title=title,
@@ -535,5 +737,10 @@ class GatewayUI:
                 path = path[len(root) :] or "/"
             if isinstance(route, Mount):
                 self._web_app.app.routes.append(Mount(path, app=route.app))
+                continue
+            if isinstance(route, WebSocketRoute):
+                # The wire carries gateway state, so it sits behind the same dependencies as the page
+                # and tree rather than being registered as a plain (and, on this router, GET) route.
+                app_router.add_api_websocket_route(path, route.endpoint, name=f"spaday:ws:{path}")
                 continue
             app_router.add_api_route(path, _authed_route(route.endpoint), methods=["GET"], include_in_schema=False, name=f"spaday:{path}")

--- a/csp_gateway/tests/server/gateway/csp/test_stage.py
+++ b/csp_gateway/tests/server/gateway/csp/test_stage.py
@@ -15,7 +15,7 @@ from csp_gateway import (
     GatewayStruct,
     State,
 )
-from csp_gateway.server.gateway.csp.stage import Stage, Staging, _StageManager
+from csp_gateway.server.gateway.csp.stage import Stage, Staging, StagingAction, StagingEvent, StagingRequest, _StageManager
 from csp_gateway.testing import GatewayTestHarness
 from csp_gateway.utils import NoProviderException
 
@@ -495,3 +495,288 @@ class TestStagingHarness:
             assert gateway.channels.stage_list("orders") == []
         finally:
             gateway.stop()
+
+
+# --- Staging event stream ---
+
+
+def _events():
+    """A _StageManager plus the (action, staging_id, item_ids) deltas it reports."""
+    captured = []
+
+    def on_event(events):
+        captured.extend((action, sid, [i.id for i in items]) for action, sid, items in events)
+
+    return _StageManager(on_event=on_event), captured
+
+
+class TestStagingEvents:
+    def test_empty_staging_reports_created(self):
+        stage, captured = _events()
+        (sid,) = stage.stage_add()
+        assert captured == [(StagingAction.CREATED, sid, [])]
+
+    def test_first_add_reports_created_then_added(self):
+        stage, captured = _events()
+        s = OrderStruct(symbol="AAPL")
+        (sid,) = stage.stage_add(s)
+        assert captured == [(StagingAction.CREATED, sid, []), (StagingAction.ADDED, sid, [s.id])]
+
+    def test_subsequent_add_reports_only_added(self):
+        stage, captured = _events()
+        (sid,) = stage.stage_add(OrderStruct(symbol="AAPL"))
+        captured.clear()
+        s2 = OrderStruct(symbol="GOOG")
+        stage.stage_add(s2, staging_ids=[sid])
+        assert captured == [(StagingAction.ADDED, sid, [s2.id])]
+
+    def test_removing_a_record_reports_removed(self):
+        stage, captured = _events()
+        s = OrderStruct(symbol="AAPL")
+        (sid,) = stage.stage_add(s)
+        captured.clear()
+        stage.stage_remove(s, staging_ids=[sid])
+        assert captured == [(StagingAction.REMOVED, sid, [s.id])]
+
+    def test_clearing_contents_reports_one_removal_per_record(self):
+        stage, captured = _events()
+        s1, s2 = OrderStruct(symbol="AAPL"), OrderStruct(symbol="GOOG")
+        (sid,) = stage.stage_add(s1)
+        stage.stage_add(s2, staging_ids=[sid])
+        captured.clear()
+        stage.stage_remove(staging_ids=[sid])
+        assert captured == [(StagingAction.REMOVED, sid, [s1.id]), (StagingAction.REMOVED, sid, [s2.id])]
+
+    def test_dropping_a_staging_reports_its_records_then_itself(self):
+        stage, captured = _events()
+        s = OrderStruct(symbol="AAPL")
+        (sid,) = stage.stage_add(s)
+        captured.clear()
+        stage.stage_remove()  # drops the latest staging entirely
+        assert captured == [(StagingAction.REMOVED, sid, [s.id]), (StagingAction.REMOVED, sid, [])]
+
+    def test_release_reports_released_with_its_contents(self):
+        stage, captured = _events()
+        s1, s2 = OrderStruct(symbol="AAPL"), OrderStruct(symbol="GOOG")
+        (sid,) = stage.stage_add(s1)
+        stage.stage_add(s2, staging_ids=[sid])
+        captured.clear()
+        stage.stage_release([sid])
+        assert captured == [(StagingAction.RELEASED, sid, [s1.id, s2.id])]
+
+    def test_no_op_removal_reports_nothing(self):
+        stage, captured = _events()
+        stage.stage_add(OrderStruct(symbol="AAPL"))
+        captured.clear()
+        stage.stage_remove(OrderStruct(symbol="MSFT"), staging_ids=[])
+        assert captured == []
+
+    def test_events_are_optional(self):
+        # The manager is usable without an observer (the REST-only path).
+        stage = _StageManager()
+        (sid,) = stage.stage_add(OrderStruct(symbol="AAPL"))
+        assert stage.stage_list() == [sid]
+
+    def test_released_stagings_are_not_retained(self):
+        # A release is delivered on the channel and as an event; the area itself is dropped rather than
+        # archived, so lookups do not grow without bound.
+        stage, _captured = _events()
+        (sid,) = stage.stage_add(OrderStruct(symbol="AAPL"))
+        stage.stage_release([sid])
+        assert stage.stage_list() == []
+        assert stage.stage_lookup() == {}
+        assert stage.stage_lookup(sid) == {}
+
+
+@csp.node
+def _collect_stage_events(events: ts[StagingEvent], out: list) -> None:
+    if csp.ticked(events):
+        out.append((events.action, events.staging_id, [i.symbol for i in events.items]))
+
+
+@csp.node
+def _mirror_staging(events: ts[StagingEvent], channels: object, field: str) -> None:
+    """Build a derived staging from an upstream one, and follow its release."""
+    if csp.ticked(events):
+        if events.action == StagingAction.ADDED:
+            for item in events.items:
+                channels.stage_add(field, OrderStruct(symbol=f"HEDGE:{item.symbol}", quantity=-item.quantity))
+        elif events.action == StagingAction.RELEASED:
+            channels.stage_release(field)
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        sock.listen(1)
+        return sock.getsockname()[1]
+
+
+def _wait_for(predicate, timeout: float = 5.0) -> None:
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError("timed out waiting for staging events")
+
+
+class TestStagingEventChannel:
+    """`get_stage_events` exposes the delta stream to modules as a normal timeseries."""
+
+    def test_events_reach_a_module_through_the_graph(self):
+        from csp_gateway import GatewaySettings
+
+        collected = []
+
+        class EventChannels(GatewayChannels):
+            orders: ts[OrderStruct] = None
+
+        class Producer(GatewayModule):
+            def connect(self, channels: EventChannels) -> None:
+                channels.set_channel("orders", csp.null_ts(OrderStruct))
+                channels.set_stage("orders")
+
+        class Observer(GatewayModule):
+            def connect(self, channels: EventChannels) -> None:
+                _collect_stage_events(channels.get_stage_events("orders"), collected)
+
+        class EventGateway(Gateway):
+            channels_model: type[Channels] = EventChannels  # type: ignore[assignment]
+
+        gateway = EventGateway(
+            modules=[Producer(), Observer()],
+            channels=EventChannels(),
+            settings=GatewaySettings(PORT=_free_port()),
+        )
+        gateway.start(rest=True, _in_test=True)
+        try:
+            order = OrderStruct(symbol="AAPL", quantity=10)
+            (sid,) = gateway.channels.stage_add("orders", order)
+            _wait_for(lambda: len(collected) >= 2)
+            assert collected[0] == (StagingAction.CREATED, sid, [])
+            assert collected[1] == (StagingAction.ADDED, sid, ["AAPL"])
+
+            gateway.channels.stage_release("orders", staging_ids=[sid])
+            _wait_for(lambda: any(e[0] == StagingAction.RELEASED for e in collected))
+            assert (StagingAction.RELEASED, sid, ["AAPL"]) in collected
+        finally:
+            gateway.stop()
+
+    def test_a_module_can_derive_and_cascade_a_staging(self):
+        # The motivating case: react to an upstream staging, build your own, and release it when the
+        # upstream one releases.
+        from csp_gateway import GatewaySettings
+
+        class CascadeChannels(GatewayChannels):
+            orders: ts[OrderStruct] = None
+            hedges: ts[OrderStruct] = None
+
+        class Producer(GatewayModule):
+            def connect(self, channels: CascadeChannels) -> None:
+                channels.set_channel("orders", csp.null_ts(OrderStruct))
+                channels.set_stage("orders")
+
+        class Hedger(GatewayModule):
+            def connect(self, channels: CascadeChannels) -> None:
+                channels.set_channel("hedges", csp.null_ts(OrderStruct))
+                channels.set_stage("hedges")
+                _mirror_staging(channels.get_stage_events("orders"), channels, "hedges")
+
+        class CascadeGateway(Gateway):
+            channels_model: type[Channels] = CascadeChannels  # type: ignore[assignment]
+
+        gateway = CascadeGateway(
+            modules=[Producer(), Hedger()],
+            channels=CascadeChannels(),
+            settings=GatewaySettings(PORT=_free_port()),
+        )
+        gateway.start(rest=True, _in_test=True)
+        try:
+            (sid,) = gateway.channels.stage_add("orders", OrderStruct(symbol="AAPL", quantity=10))
+
+            # The hedger staged its own derived order in response.
+            _wait_for(lambda: gateway.channels.stage_list("hedges"))
+            (hedge_sid,) = gateway.channels.stage_list("hedges")
+            hedged = gateway.channels.stage_lookup("hedges", hedge_sid)[hedge_sid]
+            assert [(h.symbol, h.quantity) for h in hedged] == [("HEDGE:AAPL", -10)]
+
+            # Releasing upstream releases the derived staging too.
+            gateway.channels.stage_release("orders", staging_ids=[sid])
+            _wait_for(lambda: not gateway.channels.stage_list("hedges"))
+            assert gateway.channels.stage_list("hedges") == []
+        finally:
+            gateway.stop()
+
+
+class TestStagingRequests:
+    """`set_stage_requests` drives staging from a timeseries instead of imperative calls."""
+
+    def test_requests_stage_and_release_from_the_graph(self):
+        from csp_gateway import GatewaySettings
+
+        class RequestChannels(GatewayChannels):
+            orders: ts[OrderStruct] = None
+
+        class Requester(GatewayModule):
+            def connect(self, channels: RequestChannels) -> None:
+                channels.set_channel("orders", csp.null_ts(OrderStruct))
+                channels.set_stage("orders")
+                requests = csp.curve(
+                    StagingRequest,
+                    [
+                        (timedelta(seconds=0.1), StagingRequest(action=StagingAction.ADDED, items=[OrderStruct(symbol="AAPL", quantity=5)])),
+                        (timedelta(seconds=0.2), StagingRequest(action=StagingAction.ADDED, items=[OrderStruct(symbol="GOOG", quantity=7)])),
+                    ],
+                )
+                channels.set_stage_requests("orders", requests)
+
+        class RequestGateway(Gateway):
+            channels_model: type[Channels] = RequestChannels  # type: ignore[assignment]
+
+        gateway = RequestGateway(
+            modules=[Requester()],
+            channels=RequestChannels(),
+            settings=GatewaySettings(PORT=_free_port()),
+        )
+        gateway.start(rest=True, _in_test=True)
+        try:
+            _wait_for(lambda: gateway.channels.stage_list("orders"))
+            (sid,) = gateway.channels.stage_list("orders")
+            _wait_for(lambda: len(gateway.channels.stage_lookup("orders", sid).get(sid, [])) == 2)
+            staged = gateway.channels.stage_lookup("orders", sid)[sid]
+            assert [s.symbol for s in staged] == ["AAPL", "GOOG"]
+        finally:
+            gateway.stop()
+
+    def test_requests_require_staging_to_be_enabled(self):
+        from csp_gateway import GatewaySettings
+
+        class PlainChannels(GatewayChannels):
+            orders: ts[OrderStruct] = None
+
+        class BadModule(GatewayModule):
+            def connect(self, channels: PlainChannels) -> None:
+                channels.set_channel("orders", csp.null_ts(OrderStruct))
+                with pytest.raises(NoProviderException, match="No staging enabled"):
+                    channels.set_stage_requests("orders", csp.null_ts(StagingRequest))
+
+        class PlainGateway(Gateway):
+            channels_model: type[Channels] = PlainChannels  # type: ignore[assignment]
+
+        gateway = PlainGateway(
+            modules=[BadModule()],
+            channels=PlainChannels(),
+            settings=GatewaySettings(PORT=_free_port()),
+        )
+        gateway.start(rest=True, _in_test=True)
+        gateway.stop()
+
+    def test_get_stage_events_requires_staging_to_be_enabled(self):
+        channels = GatewayChannels()
+        with pytest.raises(NoProviderException, match="No staging enabled"):
+            channels.get_stage_events("nope")

--- a/csp_gateway/tests/server/web/test_spaday_wire.py
+++ b/csp_gateway/tests/server/web/test_spaday_wire.py
@@ -1,0 +1,215 @@
+"""Tests for the spaday UI's transports wire: namespacing and per-identity tenancy."""
+
+import json
+from typing import Any
+
+import csp
+import pytest
+from csp import ts
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from starlette.websockets import WebSocketDisconnect
+
+from csp_gateway import (
+    Gateway,
+    GatewayChannels,
+    GatewayModule,
+    GatewaySettings,
+    GatewayStruct,
+    MountRestRoutes,
+)
+from csp_gateway.server.middleware.api_key_external import MountExternalAPIKeyMiddleware
+from csp_gateway.testing.mock_validators import mock_api_key_validator_by_user
+
+pytest.importorskip("spaday")
+pytest.importorskip("transports")
+
+
+class Example(GatewayStruct):
+    value: float = 0.0
+
+
+class ExampleChannels(GatewayChannels):
+    example: ts[Example] = None
+
+
+class ExampleModule(GatewayModule):
+    def connect(self, channels: ExampleChannels) -> None:
+        channels.set_channel("example", csp.null_ts(Example))
+
+
+class Rows(BaseModel):
+    rows: list = []
+
+
+class PublishingModule(GatewayModule):
+    """Declares a live model and publishes a per-identity view of it."""
+
+    # GatewayModule is a pydantic model, so the handle needs a declared field to live on.
+    handle: Any = None
+
+    def connect(self, channels: ExampleChannels) -> None: ...
+
+    def ui(self, app) -> None:
+        self.handle = app.model("staging", Rows)
+
+    def publish_per_identity(self) -> None:
+        # Each tenant only ever sees rows carrying its own user.
+        self.handle.publish(lambda identity: {"rows": [{"user": (identity or {}).get("user", "anon")}]})
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+class TestWireDeclaration:
+    def test_no_model_declared_serves_no_websocket(self):
+        gateway = Gateway(
+            modules=[ExampleModule(), MountRestRoutes(force_mount_all=True)],
+            channels=ExampleChannels(),
+            settings=GatewaySettings(PORT=_free_port(), UI_PROVIDER="spaday"),
+        )
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            client = TestClient(gateway.web_app.get_fastapi())
+            with pytest.raises(WebSocketDisconnect) as excinfo, client.websocket_connect("/ws"):
+                pass
+            # 1000 is Starlette closing an unrouted websocket. Asserting the code keeps this from
+            # passing on a 1008 rejection, which would mean the route exists but refuses every client.
+            assert excinfo.value.code == 1000
+        finally:
+            gateway.stop()
+
+    def test_declaring_a_model_serves_a_websocket(self):
+        gateway = Gateway(
+            modules=[ExampleModule(), PublishingModule(), MountRestRoutes(force_mount_all=True)],
+            channels=ExampleChannels(),
+            settings=GatewaySettings(PORT=_free_port(), UI_PROVIDER="spaday"),
+        )
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            client = TestClient(gateway.web_app.get_fastapi())
+            with client.websocket_connect("/ws") as ws:
+                snapshot = json.loads(ws.receive_text())
+            assert snapshot["t"] == "snapshot"
+            assert snapshot["type"] == "Rows"
+        finally:
+            gateway.stop()
+
+    def test_the_wire_carries_state_published_before_the_client_connected(self):
+        publisher = PublishingModule()
+        gateway = Gateway(
+            modules=[ExampleModule(), publisher, MountRestRoutes(force_mount_all=True)],
+            channels=ExampleChannels(),
+            settings=GatewaySettings(PORT=_free_port(), UI_PROVIDER="spaday"),
+        )
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            publisher.publish_per_identity()
+            client = TestClient(gateway.web_app.get_fastapi())
+            with client.websocket_connect("/ws") as ws:
+                snapshot = json.loads(ws.receive_text())
+            assert snapshot["value"] == {"Map": {"rows": {"List": [{"Map": {"user": {"Str": "anon"}}}]}}}
+        finally:
+            gateway.stop()
+
+    def test_namespaces_cannot_collide(self):
+        gateway = Gateway(
+            modules=[ExampleModule(), PublishingModule(), MountRestRoutes(force_mount_all=True)],
+            channels=ExampleChannels(),
+            settings=GatewaySettings(PORT=_free_port(), UI_PROVIDER="spaday"),
+        )
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            with pytest.raises(ValueError, match="already declared"):
+                gateway.web_app.ui.model("staging", Rows)
+        finally:
+            gateway.stop()
+
+    def test_page_wires_the_declared_namespace(self):
+        gateway = Gateway(
+            modules=[ExampleModule(), PublishingModule(), MountRestRoutes(force_mount_all=True)],
+            channels=ExampleChannels(),
+            settings=GatewaySettings(PORT=_free_port(), UI_PROVIDER="spaday"),
+        )
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            page = TestClient(gateway.web_app.get_fastapi()).get("/").text
+            assert "staging" in page
+            assert "/ws" in page
+        finally:
+            gateway.stop()
+
+
+class TestTenancy:
+    """Per-identity tenancy is what keeps the wire from bypassing AuthFilterMiddleware."""
+
+    @pytest.fixture(scope="class")
+    def gateway(self):
+        gateway = Gateway(
+            modules=[
+                ExampleModule(),
+                PublishingModule(),
+                MountRestRoutes(force_mount_all=True),
+                MountExternalAPIKeyMiddleware(external_validator=mock_api_key_validator_by_user),
+            ],
+            channels=ExampleChannels(),
+            settings=GatewaySettings(PORT=_free_port(), UI_PROVIDER="spaday"),
+        )
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            yield gateway
+        finally:
+            gateway.stop()
+
+    def test_unauthenticated_connections_share_the_anonymous_tenant(self, gateway):
+        import asyncio
+
+        from csp_gateway.server.web.spaday_ui import _ANONYMOUS_TENANT
+
+        ui = gateway.web_app.ui
+
+        class _Sock:
+            cookies: dict = {}
+            headers: dict = {}
+            query_params: dict = {}
+
+        tenant, identity = asyncio.run(ui._tenant_for(_Sock()))
+        assert tenant == _ANONYMOUS_TENANT
+        assert identity is None
+
+    def test_distinct_identities_get_distinct_tenants(self, gateway):
+        ui = gateway.web_app.ui
+        ui._host_tenant("alice", {"user": "alice"})
+        ui._host_tenant("bob", {"user": "bob"})
+
+        module = next(m for m in gateway.modules if isinstance(m, PublishingModule))
+        module.publish_per_identity()
+
+        alice_model, _ = ui._tenant_models["alice"]["staging"]
+        bob_model, _ = ui._tenant_models["bob"]["staging"]
+        assert alice_model.rows == [{"user": "alice"}]
+        assert bob_model.rows == [{"user": "bob"}]
+
+    def test_a_new_tenant_is_seeded_with_current_state(self, gateway):
+        ui = gateway.web_app.ui
+        module = next(m for m in gateway.modules if isinstance(m, PublishingModule))
+        module.publish_per_identity()
+
+        ui._host_tenant("carol", {"user": "carol"})
+        carol_model, _ = ui._tenant_models["carol"]["staging"]
+        assert carol_model.rows == [{"user": "carol"}]
+
+    def test_publishing_before_the_loop_is_up_is_not_lost(self, gateway):
+        ui = gateway.web_app.ui
+        module = next(m for m in gateway.modules if isinstance(m, PublishingModule))
+        ui._loop = None  # as during startup, before any connection
+        module.handle.publish({"rows": [{"user": "seeded"}]})
+
+        ui._host_tenant("dave", {"user": "dave"})
+        dave_model, _ = ui._tenant_models["dave"]["staging"]
+        assert dave_model.rows == [{"user": "seeded"}]

--- a/csp_gateway/tests/server/web/test_staging_panel.py
+++ b/csp_gateway/tests/server/web/test_staging_panel.py
@@ -1,0 +1,325 @@
+"""Tests for the spaday staging panel (`MountStagingPanel`).
+
+The panel is a reactive template: its structure ships in `/tree.json`, while the staged records ride the
+UI's transports wire. So the tree tests assert the *template*, and the data tests assert the *snapshot*.
+"""
+
+import json
+
+import csp
+import pytest
+from csp import ts
+from fastapi.testclient import TestClient
+
+from csp_gateway import (
+    ChannelSelection,
+    Gateway,
+    GatewayChannels,
+    GatewayModule,
+    GatewaySettings,
+    GatewayStruct,
+    MountRestRoutes,
+    MountSendForm,
+    MountStagingPanel,
+)
+
+pytest.importorskip("spaday")
+pytest.importorskip("transports")
+
+
+class Order(GatewayStruct):
+    symbol: str = ""
+    quantity: int = 0
+
+
+class StagedChannels(GatewayChannels):
+    orders: ts[Order] = None
+    other: ts[Order] = None
+
+
+class StagingModule(GatewayModule):
+    def connect(self, channels: StagedChannels) -> None:
+        channels.set_channel("orders", csp.null_ts(Order))
+        channels.set_channel("other", csp.null_ts(Order))
+        channels.set_stage("orders")
+        channels.set_stage("other")
+        channels.add_send_channel("orders")
+
+
+def _stage(client: TestClient, **fields) -> str:
+    """Stage one record and return its staging id."""
+    response = client.post("/api/v1/stage/orders", json=fields)
+    assert response.status_code == 200, response.text
+    return next(iter(response.json()))
+
+
+def _clear(client: TestClient) -> None:
+    client.request("DELETE", "/api/v1/stage/orders?id=")
+    client.request("DELETE", "/api/v1/stage/other?id=")
+
+
+def _panel_of(gateway) -> MountStagingPanel:
+    return next(m for m in gateway.modules if isinstance(m, MountStagingPanel))
+
+
+def _areas(gateway) -> list:
+    return _panel_of(gateway)._snapshot().areas
+
+
+class TestStagingSnapshot:
+    """What the panel publishes over the wire."""
+
+    @pytest.fixture(scope="class")
+    def gateway(self, free_port):
+        return Gateway(
+            modules=[StagingModule(), MountRestRoutes(force_mount_all=True), MountStagingPanel()],
+            channels=StagedChannels(),
+            settings=GatewaySettings(PORT=free_port, UI_PROVIDER="spaday"),
+        )
+
+    @pytest.fixture(scope="class")
+    def client(self, gateway):
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            yield TestClient(gateway.web_app.get_fastapi())
+        finally:
+            gateway.stop()
+
+    @pytest.fixture(autouse=True)
+    def _clean(self, client):
+        _clear(client)
+        yield
+        _clear(client)
+
+    def test_nothing_staged_is_empty(self, gateway, client: TestClient):
+        snapshot = _panel_of(gateway)._snapshot()
+        assert snapshot.empty is True
+        assert snapshot.areas == []
+
+    def test_a_staging_becomes_an_area(self, gateway, client: TestClient):
+        staging_id = _stage(client, symbol="AAPL", quantity=10)
+        client.post(f"/api/v1/stage/orders?id={staging_id}", json={"symbol": "MSFT", "quantity": 20})
+
+        snapshot = _panel_of(gateway)._snapshot()
+        assert snapshot.empty is False
+        (area,) = snapshot.areas
+        assert area.channel == "orders"
+        assert area.summary == "2 staged"
+        assert area.url == f"/api/v1/stage/orders?id={staging_id}"
+        assert [cell.value for record in area.records for cell in record.cells] == ["AAPL", "10", "MSFT", "20"]
+
+    def test_each_struct_field_becomes_a_column(self, gateway, client: TestClient):
+        _stage(client, symbol="AAPL", quantity=10)
+        (area,) = _areas(gateway)
+        assert [column.id for column in area.columns] == ["symbol", "quantity"]
+
+    def test_excluded_columns_are_omitted(self, gateway, client: TestClient):
+        panel = _panel_of(gateway)
+        _stage(client, symbol="AAPL", quantity=10)
+        (area,) = _areas(gateway)
+        assert set(panel.excluded_columns).isdisjoint(column.id for column in area.columns)
+
+    def test_records_carry_their_own_id(self, gateway, client: TestClient):
+        staging_id = _stage(client, symbol="AAPL", quantity=10)
+        record_id = client.put(f"/api/v1/stage/orders?id={staging_id}").json()[staging_id][0]["id"]
+        (area,) = _areas(gateway)
+        assert [record.id for record in area.records] == [record_id]
+
+    def test_removing_a_record_drops_it(self, gateway, client: TestClient):
+        staging_id = _stage(client, symbol="AAPL", quantity=10)
+        client.post(f"/api/v1/stage/orders?id={staging_id}", json={"symbol": "MSFT", "quantity": 20})
+        record_id = client.put(f"/api/v1/stage/orders?id={staging_id}").json()[staging_id][0]["id"]
+
+        client.request("DELETE", f"/api/v1/stage/orders?id={staging_id}", json={"id": record_id})
+
+        (area,) = _areas(gateway)
+        values = [cell.value for record in area.records for cell in record.cells]
+        assert "AAPL" not in values
+        assert "MSFT" in values  # the sibling record is untouched
+
+    def test_released_staging_disappears(self, gateway, client: TestClient):
+        staging_id = _stage(client, symbol="AAPL", quantity=10)
+        client.patch(f"/api/v1/stage/orders?id={staging_id}")
+        assert _panel_of(gateway)._snapshot().empty is True
+
+    def test_multiple_stagings_are_separate_areas(self, gateway, client: TestClient):
+        first = _stage(client, symbol="AAPL", quantity=10)
+        second = next(iter(client.post("/api/v1/stage/orders").json()))
+        assert {area.id for area in _areas(gateway)} == {f"orders:{first}", f"orders:{second}"}
+
+    def test_max_records_bounds_the_payload(self, gateway, client: TestClient):
+        panel = _panel_of(gateway)
+        staging_id = _stage(client, symbol="A0", quantity=0)
+        for i in range(1, 5):
+            client.post(f"/api/v1/stage/orders?id={staging_id}", json={"symbol": f"A{i}", "quantity": i})
+
+        original = panel.max_records
+        panel.max_records = 2
+        try:
+            (area,) = _areas(gateway)
+            assert area.summary == "5 staged"
+            assert len(area.records) == 2
+            assert area.overflow == "+3 more"
+        finally:
+            panel.max_records = original
+
+
+class TestStagingTemplate:
+    """What ships in the tree: a repeater template, not the records themselves."""
+
+    @pytest.fixture(scope="class")
+    def gateway(self, free_port):
+        return Gateway(
+            modules=[StagingModule(), MountRestRoutes(force_mount_all=True), MountStagingPanel()],
+            channels=StagedChannels(),
+            settings=GatewaySettings(PORT=free_port, UI_PROVIDER="spaday"),
+        )
+
+    @pytest.fixture(scope="class")
+    def client(self, gateway):
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            yield TestClient(gateway.web_app.get_fastapi())
+        finally:
+            gateway.stop()
+
+    def test_the_tree_repeats_over_the_wire_namespace(self, client: TestClient):
+        tree = client.get("/tree.json").text
+        assert '"tag": "spa-each"' in tree
+        assert '"staging.areas"' in tree
+        # Scopes let a row's delete reach its own staging's url and its own record id.
+        assert '"scopeName": {"Str": "area"}' in tree
+        assert '"scopeName": {"Str": "record"}' in tree
+
+    def test_the_tree_carries_no_staged_records(self, client: TestClient):
+        _stage(client, symbol="AAPL", quantity=10)
+        try:
+            # The template is static; records arrive over the wire, so the tree must not embed them.
+            assert '"textContent": {"Str": "AAPL"}' not in client.get("/tree.json").text
+        finally:
+            _clear(client)
+
+    def test_row_delete_and_release_are_scoped(self, client: TestClient):
+        blob = client.get("/tree.json").text
+        assert '"method": "DELETE"' in blob
+        assert '"method": "PATCH"' in blob
+        # A row's delete resolves its own staging's url and its own record id from the enclosing scopes.
+        assert '"url": {"expr": "scope", "name": "area", "path": "url"}' in blob
+        assert '"id": {"expr": "scope", "name": "record", "path": "id"}' in blob
+        # Release targets the area currently being repeated.
+        assert '"method": "PATCH", "url": {"expr": "item", "path": "url"}' in blob
+
+
+class TestStagingLiveUpdates:
+    """The point of the wire: staging changes reach a connected client without a page load."""
+
+    @pytest.fixture(scope="class")
+    def gateway(self, free_port):
+        return Gateway(
+            modules=[StagingModule(), MountRestRoutes(force_mount_all=True), MountStagingPanel()],
+            channels=StagedChannels(),
+            settings=GatewaySettings(PORT=free_port, UI_PROVIDER="spaday"),
+        )
+
+    @pytest.fixture(scope="class")
+    def client(self, gateway):
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            yield TestClient(gateway.web_app.get_fastapi())
+        finally:
+            gateway.stop()
+
+    def test_a_connected_client_is_told_about_a_new_staging(self, client: TestClient):
+        _clear(client)
+        try:
+            with client.websocket_connect("/ws") as ws:
+                snapshot = json.loads(ws.receive_text())
+                assert snapshot["t"] == "snapshot"
+
+                _stage(client, symbol="AAPL", quantity=10)
+
+                # The update carries the new record without the page being rebuilt.
+                for _ in range(20):
+                    frame = json.loads(ws.receive_text())
+                    if "AAPL" in json.dumps(frame):
+                        break
+                else:
+                    raise AssertionError("no frame carried the staged record")
+        finally:
+            _clear(client)
+
+
+class TestStagingPanelSelection:
+    """The panel only reports channels selected by `mount_staging`."""
+
+    @pytest.fixture(scope="class")
+    def gateway(self, free_port):
+        return Gateway(
+            modules=[
+                StagingModule(),
+                MountRestRoutes(force_mount_all=True),
+                MountStagingPanel(mount_staging=ChannelSelection(include=["other"])),
+            ],
+            channels=StagedChannels(),
+            settings=GatewaySettings(PORT=free_port, UI_PROVIDER="spaday"),
+        )
+
+    @pytest.fixture(scope="class")
+    def client(self, gateway):
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            yield TestClient(gateway.web_app.get_fastapi())
+        finally:
+            gateway.stop()
+
+    def test_unselected_channel_is_not_reported(self, gateway, client: TestClient):
+        _stage(client, symbol="AAPL", quantity=10)
+        try:
+            assert _panel_of(gateway)._snapshot().empty is True
+        finally:
+            _clear(client)
+
+
+class TestStagingPanelSharesTheBottomDrawer:
+    """With the send form alongside it, the bottom drawer presents both panels as tabs."""
+
+    @pytest.fixture(scope="class")
+    def gateway(self, free_port):
+        return Gateway(
+            modules=[StagingModule(), MountRestRoutes(force_mount_all=True), MountSendForm(), MountStagingPanel()],
+            channels=StagedChannels(),
+            settings=GatewaySettings(PORT=free_port, UI_PROVIDER="spaday"),
+        )
+
+    @pytest.fixture(scope="class")
+    def client(self, gateway):
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            yield TestClient(gateway.web_app.get_fastapi())
+        finally:
+            gateway.stop()
+
+    def test_both_panels_become_tabs(self, client: TestClient):
+        tree = client.get("/tree.json").text
+        assert '"tag": "wa-tab-group"' in tree
+        assert '"textContent": {"Str": "Send data to channel"}' in tree
+        assert '"textContent": {"Str": "Staged data"}' in tree
+
+
+class TestStagingPanelDefaultUI:
+    """Under the default (React) provider the module contributes no UI at all."""
+
+    @pytest.fixture(scope="class")
+    def gateway(self, free_port):
+        return Gateway(
+            modules=[StagingModule(), MountRestRoutes(force_mount_all=True), MountStagingPanel()],
+            channels=StagedChannels(),
+            settings=GatewaySettings(PORT=free_port, UI=True),
+        )
+
+    def test_gateway_starts_without_the_spaday_provider(self, gateway):
+        gateway.start(rest=True, ui=True, _in_test=True)
+        try:
+            assert gateway.web_app.ui is None
+        finally:
+            gateway.stop()

--- a/docs/wiki/Staging.md
+++ b/docs/wiki/Staging.md
@@ -1,0 +1,140 @@
+# Staging
+
+Staging lets structs be accumulated into named **staging areas** and released into a channel as a
+batch, rather than sent one at a time. A staging area is identified by a `staging_id` and holds a list
+of structs that have been staged but not yet released.
+
+Staging is available over REST, from Python, and from inside the csp graph.
+
+## Enabling staging
+
+Either declare it on the channel:
+
+```python
+from typing import Annotated
+from csp_gateway.server.gateway.csp.stage import Stage
+
+class MyChannels(GatewayChannels):
+    orders: Annotated[ts[OrderStruct], Stage()] = None
+```
+
+or enable it in a module's `connect`:
+
+```python
+channels.set_stage("orders")
+```
+
+Both are equivalent, and enabling a channel twice is a no-op. `channels.staged_channels()` lists the
+channels that have staging enabled.
+
+## Operations
+
+`struct` and `staging_ids` combine to select what is affected. The distinction between `None` (unset)
+and `[]` (empty list) is meaningful for `staging_ids`.
+
+### `stage_add(field, struct=None, staging_ids=None)`
+
+| `struct` | `staging_ids`  | Effect                                                                                                         |
+| -------- | -------------- | -------------------------------------------------------------------------------------------------------------- |
+| `None`   | `None` or `[]` | Open a new empty staging area                                                                                  |
+| `None`   | `[ids]`        | `ValueError` — nothing to add                                                                                  |
+| struct   | `None`         | Add to the most recent staging, or open one if none exist                                                      |
+| struct   | `[]`           | Add to every staging that does not already hold it; open one if none exist, or if it is already in all of them |
+| struct   | `[ids]`        | Add to each named staging; `KeyError` if an id is unknown                                                      |
+
+Returns the list of staging ids affected.
+
+### `stage_remove(field, struct=None, staging_ids=None)`
+
+| `struct` | `staging_ids` | Effect                                           |
+| -------- | ------------- | ------------------------------------------------ |
+| `None`   | `None`        | Drop the most recent staging area entirely       |
+| `None`   | `[]`          | Drop every staging area                          |
+| `None`   | `[ids]`       | Empty the named staging areas, leaving them open |
+| struct   | `None`        | Remove from the most recent staging holding it   |
+| struct   | `[]`          | Remove from every staging holding it             |
+| struct   | `[ids]`       | Remove from each named staging                   |
+
+Note the asymmetry: with no `struct`, an unset `staging_ids` **drops** a staging area, while naming
+ids only **empties** them.
+
+A struct is matched by its `id`, so a partial struct carrying just the right `id` is enough to remove
+a record.
+
+Returns the list of staging ids affected.
+
+### `stage_release(field, staging_ids=None)`
+
+Releases the staged structs into the channel — each is ticked individually. Passing no ids releases
+every staging area. Returns `{staging_id: [structs]}`.
+
+A released staging area is **dropped**, not archived: its contents have been delivered on the channel
+and on the release event, so it no longer appears in `stage_list` or `stage_lookup`.
+
+### `stage_list(field, staging_id=None)` and `stage_lookup(field, staging_id=None)`
+
+`stage_list` returns the pending staging ids, or `[staging_id]` if that one is pending and `[]` if it
+is not. `stage_lookup` returns `{staging_id: [structs]}` for the pending areas.
+
+## REST API
+
+Each staged channel is mounted under `/api/v1/stage/{channel}` by `MountRestRoutes`. The `id` query
+parameter is a comma-separated list of staging ids; omitting it is the unset case above, and passing
+it empty (`?id=`) is the empty-list case.
+
+| Method   | Operation                                                    |
+| -------- | ------------------------------------------------------------ |
+| `POST`   | `stage_add` — body is the struct, or empty to open a staging |
+| `DELETE` | `stage_remove` — body is the struct, or empty to empty/drop  |
+| `PATCH`  | `stage_release`                                              |
+| `GET`    | `stage_list`                                                 |
+| `PUT`    | `stage_lookup`                                               |
+
+A validator rejecting a staged struct surfaces as a `422`; see
+[Develop](Develop#Custom-Struct-Validators).
+
+## Observing staging from the graph
+
+Every staging mutation is published as a `ts[StagingEvent]` delta stream, one tick per affected
+record:
+
+```python
+events = channels.get_stage_events("orders")   # ts[StagingEvent]
+```
+
+| Field        | Meaning                                                      |
+| ------------ | ------------------------------------------------------------ |
+| `channel`    | The staged channel                                           |
+| `staging_id` | The staging area affected                                    |
+| `action`     | `CREATED`, `ADDED`, `REMOVED` or `RELEASED`                  |
+| `items`      | The record involved, or every released record for `RELEASED` |
+
+`CREATED` carries no items, and a staging area that is dropped reports a `REMOVED` per record followed
+by a `REMOVED` with no items for the area itself.
+
+This makes staging composable. A module can watch one channel's staging, build its own on another
+channel, and follow the upstream release:
+
+```python
+@csp.node
+def mirror(events: ts[StagingEvent], channels: object, field: str) -> None:
+    if csp.ticked(events):
+        if events.action == StagingAction.ADDED:
+            for item in events.items:
+                channels.stage_add(field, hedge_for(item))
+        elif events.action == StagingAction.RELEASED:
+            channels.stage_release(field)
+```
+
+## Driving staging from the graph
+
+Staging can also be mutated from a timeseries, as the graph-native counterpart to calling
+`stage_add`/`stage_remove`/`stage_release` directly:
+
+```python
+channels.set_stage_requests("orders", requests)   # ts[StagingRequest]
+```
+
+A `StagingRequest` carries an `action` (the same four), the `items` to stage or unstage, and
+`staging_ids`. Leaving `staging_ids` unset means the unset case above; setting it to an empty list
+means the empty-list case. A `REMOVED` request with no items empties rather than unstaging a record.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -21,6 +21,7 @@ Notes for editors:
 
 - [Configuration](Configuration)
 - [API](API)
+- [Staging](Staging)
 - [UI](UI)
 - [Client](Client)
 - [CSP Notes](CSP-Notes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,11 @@ client = [
 ]
 spaday = [
     # Optional spaday-based frontend provider (Settings.UI_PROVIDER = "spaday")
-    "spaday>=0.2.2",
+    # 0.5 splits the component libraries into their own distributions and adds the `Each` repeater the
+    # staging panel renders with.
+    "spaday>=0.5.0",
+    "spaday-perspective>=0.1.0",
+    "spaday-webawesome>=0.1.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Staging areas were only reachable over REST. This surfaces them in the spaday UI as a **"Staged data"** tab sharing the bottom drawer (the header's `+`) with the send form: a table per pending staging with a column per struct field, an X to drop a single record, and a button to release the whole staging.

The panel is reactive — staged records ride the UI's transports wire rather than being baked into the page, so stagings and records appear and disappear as they are staged and released **without a page reload**.

## Supporting changes

- **Staging observability.** A `StagingEvent` delta stream per staged channel, plus a `StagingRequest` channel so a module can drive staging from the graph (build a derived staging on another channel, release it when the upstream one is).
- **`add_stage_listener`.** Stages declared by `Annotated[ts[X], Stage()]` are wired during finalization, *after* every module's `connect`, so a graph edge cannot observe them. A callback can, and works for both declaration styles.
- **Dropped the `_released` archive.** It grew without bound and made `stage_lookup` keep returning stagings that had already been released; it is now pending-only.
- **Transports wire for the spaday provider.** Modules declare live state with `GatewayUI.model(namespace, model)`. Each connection is routed to a tenant keyed on the identity `AuthFilterMiddleware` resolves, so tenants never see each other's state; unauthenticated connections share one anonymous tenant.
- **Tabbed bottom drawer.** Region contributions may carry a label; the drawer tabs only when more than one labelled panel shares it, so a lone panel gains no chrome.
- **spaday 0.5.** Splits the component libraries into their own distributions (`spaday-webawesome`, `spaday-perspective`) and adds the `Each` repeater the panel renders with.

## Verified

`275 passed` across the web and stage suites. The broader `tests/server` run shows 98 pre-existing failures (the `typing.List` vs `list` csp typing issue), unchanged by this branch.

Beyond the unit tests, the panel was driven in a real browser against the omnibus demo, asserting on the live DOM with the page never reloading (`navigation.type` stayed `navigate`):

| action | tables | rows |
|---|---|---|
| baseline | 0 | 0 |
| stage 3 groups | 3 | 9 |
| click a row's X | 3 | 8 |
| click "Submit staging" | 2 | 6 |
| stage 10 groups | 10 | 30 |

The tests are split to match where data now lives: snapshot tests for the published state, template tests for the tree — including one asserting the tree carries *no* staged records — and a wire test that a connected client is told about a new staging.
