### PR TITLE
Frame Kafka engine cycles ourselves instead of through csp's mapper

### DIFF
--- a/csp_gateway/server/modules/kafka/kafka.py
+++ b/csp_gateway/server/modules/kafka/kafka.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, get_args, get_origin
 
 import csp
@@ -34,6 +34,47 @@ __all__ = (
     "ReadWriteKafka",
     "ReplayEngineKafka",
 )
+
+#: Wire field names of the envelope a message is wrapped in when engine timestamps are included.
+_ENVELOPE_ENCODING_FIELD = "encoding"
+_ENVELOPE_TIMESTAMP_FIELD = "csp_timestamp"
+
+
+class _EngineCycleEnvelope(csp.Struct):
+    """The envelope as csp's Kafka adapter sees it, for the one case that needs csp to parse it.
+
+    Subscribing with ``tick_timestamp_from_field`` makes csp replay each message at the engine time
+    recorded in it, which means csp -- not us -- has to read that field out of the payload. It can
+    only do that into a ``csp.Struct``, so this is the last one in the package. Everything else,
+    including the publish side, reads and writes the same wire format through `EncodedEngineCycle`.
+    """
+
+    encoding: str
+    csp_timestamp: datetime
+
+
+def _encode_envelope(encoding: str, csp_timestamp: datetime) -> str:
+    """Serialize the envelope exactly as csp's ``JSONTextMessageMapper`` would.
+
+    csp writes ``DateTimeType.UINT64_MILLIS`` as epoch milliseconds and reads it back the same way,
+    so a subscriber using the mapper parses this unchanged.
+    """
+    return orjson.dumps(
+        {
+            _ENVELOPE_ENCODING_FIELD: encoding,
+            _ENVELOPE_TIMESTAMP_FIELD: int(csp_timestamp.replace(tzinfo=timezone.utc).timestamp() * 1000),
+        }
+    ).decode()
+
+
+def _decode_envelope(message: str) -> EncodedEngineCycle:
+    """Read an envelope written by `_encode_envelope` or by csp's ``JSONTextMessageMapper``."""
+    raw = orjson.loads(message)
+    timestamp = raw.get(_ENVELOPE_TIMESTAMP_FIELD)
+    return EncodedEngineCycle(
+        encoding=raw[_ENVELOPE_ENCODING_FIELD],
+        csp_timestamp=datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc).replace(tzinfo=None) if timestamp is not None else None,
+    )
 
 
 # NOTE: If the authorization parameters are not correct, the graph may hang indefinitely
@@ -278,22 +319,24 @@ class ReadWriteKafka(GatewayModule):
         return self.serialize(x)
 
     @csp.node
-    def serialize_with_engine_timestamp_csp(self, x: ts[object]) -> ts[EncodedEngineCycle]:
-        encoding = self.serialize(x)
-        return EncodedEngineCycle(encoding=encoding, csp_timestamp=csp.now())
+    def serialize_with_engine_timestamp_csp(self, x: ts[object]) -> ts[str]:
+        return _encode_envelope(self.serialize(x), csp.now())
 
     def connect(self, channels: GatewayChannels):
+        # Published messages are always written by us as raw text. Only the subscribe side of the
+        # engine-timestamp path needs csp's JSON mapper, to read csp_timestamp back out for
+        # tick_timestamp_from_field.
         if self.encoding_with_engine_timestamps:
-            msg_mapper = JSONTextMessageMapper(datetime_type=DateTimeType.UINT64_MILLIS)
-            publish_field_map = {
-                "encoding": "encoding",
-                "csp_timestamp": "csp_timestamp",
+            subscribe_msg_mapper = JSONTextMessageMapper(datetime_type=DateTimeType.UINT64_MILLIS)
+            subscribe_ts_type = _EngineCycleEnvelope
+            subscribe_field_map = {
+                _ENVELOPE_ENCODING_FIELD: _ENVELOPE_ENCODING_FIELD,
+                _ENVELOPE_TIMESTAMP_FIELD: _ENVELOPE_TIMESTAMP_FIELD,
             }
-            subscribe_field_map = publish_field_map
         else:
-            msg_mapper = RawTextMessageMapper()
-            publish_field_map = None
-            subscribe_field_map = {"": "encoding"}
+            subscribe_msg_mapper = RawTextMessageMapper()
+            subscribe_ts_type = str
+            subscribe_field_map = None
 
         for channel_name, topic_to_key in self.publish_channel_to_topic_and_key.items():
             channel = channels.get_channel(channel_name)
@@ -311,14 +354,13 @@ class ReadWriteKafka(GatewayModule):
                 else:
                     encoded_value = self.serialize_csp(raw_value)
                 self._kafkaadapter.publish(
-                    msg_mapper=msg_mapper,
-                    field_map=publish_field_map,
+                    msg_mapper=RawTextMessageMapper(),
                     topic=topic,
                     key=key,
                     x=encoded_value,
                 )
 
-        tick_timestamp_from_field = "csp_timestamp" if self.subscribe_with_csp_engine_timestamp else None
+        tick_timestamp_from_field = _ENVELOPE_TIMESTAMP_FIELD if self.subscribe_with_csp_engine_timestamp else None
 
         for (
             channel_name,
@@ -327,16 +369,18 @@ class ReadWriteKafka(GatewayModule):
             values_to_tick = []
             for topic, key in topic_to_key.items():
                 sub = self._kafkaadapter.subscribe(
-                    ts_type=EncodedEngineCycle,
+                    ts_type=subscribe_ts_type,
                     topic=topic,
-                    msg_mapper=msg_mapper,
+                    msg_mapper=subscribe_msg_mapper,
                     key=key,
                     field_map=subscribe_field_map,
                     tick_timestamp_from_field=tick_timestamp_from_field,
                     adjust_out_of_order_time=True,
                     include_msg_before_start_time=self.include_subscribe_messages_before_engine_start,
                     push_mode=csp.PushMode.NON_COLLAPSING,
-                ).encoding
+                )
+                if self.encoding_with_engine_timestamps:
+                    sub = sub.encoding
                 channel_type = channels.get_outer_type(channel_name).typ
                 deserialized_sub = self.deserialize_csp(encoding=sub, ts_typ=channel_type)
                 channel_processor = self.subscribe_channel_processors.get(channel_name)
@@ -421,27 +465,34 @@ class ReplayEngineKafka(EngineReplay):
             poll_timeout=self.config.poll_timeout,
         )
 
+    @csp.node
+    def _extract_encoding(self, message: ts[str]) -> ts[str]:
+        if csp.ticked(message):
+            return _decode_envelope(message).encoding
+
+    @csp.node
+    def _to_envelope(self, cycle: ts[EncodedEngineCycle]) -> ts[str]:
+        if csp.ticked(cycle):
+            return _encode_envelope(cycle.encoding, cycle.csp_timestamp)
+
     @override
     def subscribe(self):
-        return self._kafkaadapter.subscribe(
-            ts_type=EncodedEngineCycle,
-            msg_mapper=JSONTextMessageMapper(datetime_type=DateTimeType.UINT64_MILLIS),
+        message = self._kafkaadapter.subscribe(
+            ts_type=str,
+            msg_mapper=RawTextMessageMapper(),
             topic=self.topic,
             key=self.key,
-            field_map={"encoding": "encoding", "csp_timestamp": "csp_timestamp"},
-            meta_field_map={"timestamp": "csp_timestamp"},  # don't use the timestamp provided by kafka, but the one encoded on the message
-            # adjust_out_of_order_time=True,  we do this in python and log when it happens
             push_mode=csp.PushMode.NON_COLLAPSING,
-        ).encoding
+        )
+        return self._extract_encoding(message)
 
     @override
     def publish(self, encoded_channels: ts[EncodedEngineCycle]):
         self._kafkaadapter.publish(
-            msg_mapper=JSONTextMessageMapper(datetime_type=DateTimeType.UINT64_MILLIS),
-            field_map={"encoding": "encoding", "csp_timestamp": "csp_timestamp"},
+            msg_mapper=RawTextMessageMapper(),
             topic=self.topic,
             key=self.key,
-            x=encoded_channels,
+            x=self._to_envelope(encoded_channels),
         )
 
     @override

--- a/csp_gateway/server/shared/json_converter.py
+++ b/csp_gateway/server/shared/json_converter.py
@@ -44,16 +44,15 @@ class ChannelValueModel(BaseModel):
     timestamp: datetime
 
 
-class EncodedEngineCycle(csp.Struct):
-    """A single engine cycle, as it travels over a csp adapter.
+class EncodedEngineCycle(PydanticBaseModel):
+    """A serialized engine cycle, plus the engine time it was produced at.
 
-    Stays a ``csp.Struct`` rather than moving to pydantic with the gateway structs: it is handed to
-    csp's Kafka adapter as a ``ts_type`` with a ``field_map``, and read back with edge field access
-    (``subscribe(...).encoding``). Both are csp.Struct-only mechanisms.
+    Plain pydantic rather than ccflow's `BaseModel`: this goes on the wire, and a ``type_``
+    discriminator would change the encoding Kafka and the replay files carry.
     """
 
-    encoding: str
-    csp_timestamp: datetime
+    encoding: str | None = None
+    csp_timestamp: datetime | None = None
 
 
 def read_engine_encoding_json_with_duckdb(channels: ChannelsType, filename: str):

--- a/csp_gateway/tests/server/modules/kafka/test_envelope.py
+++ b/csp_gateway/tests/server/modules/kafka/test_envelope.py
@@ -1,0 +1,58 @@
+"""Tests for the Kafka engine-cycle envelope.
+
+The envelope is the one place gateway data is framed by hand rather than by csp. Its shape has to
+stay byte-compatible with csp's ``JSONTextMessageMapper``, because the engine-timestamp subscribe
+path still reads it back through that mapper to recover ``csp_timestamp`` for
+``tick_timestamp_from_field``.
+"""
+
+from datetime import datetime
+
+import orjson
+
+from csp_gateway.server.modules.kafka.kafka import (
+    _ENVELOPE_ENCODING_FIELD,
+    _ENVELOPE_TIMESTAMP_FIELD,
+    _decode_envelope,
+    _encode_envelope,
+)
+
+ENCODING = '{"foo":1.0}'
+TIMESTAMP = datetime(2020, 1, 1, 0, 0, 1)
+# csp writes DateTimeType.UINT64_MILLIS as epoch milliseconds, so this is what the mapper expects.
+EPOCH_MILLIS = 1577836801000
+
+
+def test_encodes_the_two_wire_fields():
+    assert orjson.loads(_encode_envelope(ENCODING, TIMESTAMP)) == {
+        _ENVELOPE_ENCODING_FIELD: ENCODING,
+        _ENVELOPE_TIMESTAMP_FIELD: EPOCH_MILLIS,
+    }
+
+
+def test_timestamp_is_epoch_millis_not_a_string():
+    # A string here would still round trip through _decode_envelope but would fail csp's parser.
+    assert isinstance(orjson.loads(_encode_envelope(ENCODING, TIMESTAMP))[_ENVELOPE_TIMESTAMP_FIELD], int)
+
+
+def test_round_trips():
+    cycle = _decode_envelope(_encode_envelope(ENCODING, TIMESTAMP))
+    assert cycle.encoding == ENCODING
+    assert cycle.csp_timestamp == TIMESTAMP
+
+
+def test_decodes_what_csps_mapper_would_produce():
+    message = orjson.dumps({_ENVELOPE_ENCODING_FIELD: ENCODING, _ENVELOPE_TIMESTAMP_FIELD: EPOCH_MILLIS}).decode()
+    cycle = _decode_envelope(message)
+    assert cycle.encoding == ENCODING
+    assert cycle.csp_timestamp == TIMESTAMP
+
+
+def test_decodes_a_message_without_a_timestamp():
+    message = orjson.dumps({_ENVELOPE_ENCODING_FIELD: ENCODING}).decode()
+    assert _decode_envelope(message).csp_timestamp is None
+
+
+def test_encoding_is_nested_as_a_string_not_inlined():
+    # The payload is opaque to the envelope; inlining it would collide with the envelope's own keys.
+    assert orjson.loads(_encode_envelope('{"csp_timestamp":"collide"}', TIMESTAMP))[_ENVELOPE_TIMESTAMP_FIELD] == EPOCH_MILLIS

--- a/csp_gateway/tests/server/modules/kafka/test_kafka.py
+++ b/csp_gateway/tests/server/modules/kafka/test_kafka.py
@@ -15,7 +15,6 @@ from pydantic import ValidationError
 from csp_gateway import (
     AddChannelsToGraphOutput,
     ChannelSelection,
-    EncodedEngineCycle,
     GatewayStruct,
     KafkaChannelProcessor,
     KafkaConfiguration,
@@ -23,6 +22,7 @@ from csp_gateway import (
     ReadWriteMode,
     ReplayEngineKafka,
 )
+from csp_gateway.server.modules.kafka.kafka import _ENVELOPE_TIMESTAMP_FIELD, _decode_envelope
 from csp_gateway.testing.shared_helpful_classes import (
     MyGateway,
     MyGatewayChannels,
@@ -95,6 +95,29 @@ def test_subscribe_with_csp_engine_timestamp_only_if_encoding_expected():
         ReadWriteKafka(config=config, encoding_with_engine_timestamps=False, subscribe_with_csp_engine_timestamp=True)
 
 
+def _adapter_payload(subscribe_kwargs, encoding):
+    """Build what csp's Kafka adapter would hand back for the requested ``ts_type``.
+
+    The raw path yields the message text straight through; the engine-timestamp path yields the
+    envelope struct csp parsed it into.
+    """
+    ts_type = subscribe_kwargs["ts_type"]
+    if ts_type is str:
+        return encoding
+    return ts_type(encoding=encoding)
+
+
+def _published_encodings(printed):
+    """The encodings out of captured ``val_check`` lines, unwrapping the envelope when present."""
+    encodings = []
+    for line in printed.splitlines():
+        _, _, message = line.partition("val_check:")
+        if not message:
+            continue
+        encodings.append(_decode_envelope(message).encoding if _ENVELOPE_TIMESTAMP_FIELD in message else message)
+    return "".join(encodings)
+
+
 @mock.patch("csp.adapters.kafka.KafkaAdapterManager", autospec=True)
 @pytest.mark.parametrize("by_key", [True, False])
 def test_kafka_engine_replay_write(mock_object, by_key):
@@ -144,7 +167,7 @@ def test_kafka_engine_replay_read_and_write_read(mock_object, read_write_mode):
     mock_publish = mock.MagicMock()
 
     def mock_subscribe(*a, **kw):
-        return csp.null_ts(EncodedEngineCycle)
+        return csp.null_ts(kw["ts_type"])
 
     mock_object.return_value.subscribe.side_effect = mock_subscribe
     mock_object.return_value.publish = mock_publish
@@ -179,7 +202,7 @@ def test_kafka_read_write_fails_with_dict_basket(mock_object):
     mock_publish = mock.MagicMock()
 
     def mock_subscribe(*a, **kw):
-        return csp.null_ts(EncodedEngineCycle)
+        return csp.null_ts(kw["ts_type"])
 
     mock_object.return_value.subscribe.side_effect = mock_subscribe
     mock_object.return_value.publish = mock_publish
@@ -220,16 +243,14 @@ def test_kafka_read_write_read(mock_object, encoding_with_engine_timestamps, cap
         if kw["topic"] == "kafka_topic1" and kw["key"] == "kafka_key2":
             # If Kafka publishes to this key on this topic, we capture it
             # with a print statement.
-            if encoding_with_engine_timestamps:
-                csp.print("val_check", kw["x"].encoding)
-            else:
-                csp.print("val_check", kw["x"])
+            # Published messages are raw text on both paths now.
+            csp.print("val_check", kw["x"])
 
     mock_publish = mock.MagicMock(side_effect=mock_publish_action)
     # mock_publish = mock.MagicMock()
 
     def mock_subscribe(*a, **kw):
-        return csp.null_ts(EncodedEngineCycle)
+        return csp.null_ts(kw["ts_type"])
 
     mock_object.return_value.subscribe.side_effect = mock_subscribe
     mock_object.return_value.publish = mock_publish
@@ -282,13 +303,13 @@ def test_kafka_read_write_write(mock_object):
     def mock_subscribe(*a, **kw):
         if kw["topic"] == "kafka_topic1" and kw["key"] == "kafka_key":
             encoding = orjson.dumps({"foo": 9.1}).decode()
-            return csp.const(EncodedEngineCycle(encoding=encoding))
+            return csp.const(_adapter_payload(kw, encoding))
         elif kw["topic"] == "kafka_topic1" and kw["key"] == "kafka_key2":
             encoding = orjson.dumps([{"foo": 0.1}, {"my_flag": False}]).decode()
-            return csp.const(EncodedEngineCycle(encoding=encoding), timedelta(seconds=1))
+            return csp.const(_adapter_payload(kw, encoding), timedelta(seconds=1))
         elif kw["topic"] == "kafka_topic2" and kw["key"] == "kafka_key":
             encoding = orjson.dumps({"arr": [7.2, -1001.3]}).decode()
-            return csp.const(EncodedEngineCycle(encoding=encoding), timedelta(seconds=1))
+            return csp.const(_adapter_payload(kw, encoding), timedelta(seconds=1))
         else:
             raise ValueError("This should never be hit")
 
@@ -336,10 +357,10 @@ def test_kafka_read_write_write_overwrite_id_timestamp(mock_object, use_struct_i
     def mock_subscribe(*a, **kw):
         if kw["topic"] == "kafka_topic1" and kw["key"] == "kafka_key":
             encoding = orjson.dumps({"foo": 9.1, "id": "howdy"}).decode()
-            return csp.const(EncodedEngineCycle(encoding=encoding))
+            return csp.const(_adapter_payload(kw, encoding))
         elif kw["topic"] == "kafka_topic1" and kw["key"] == "kafka_key2":
             encoding = orjson.dumps([{"foo": 0.1, "timestamp": datetime(2021, 1, 1)}, {"my_flag": False}]).decode()
-            return csp.const(EncodedEngineCycle(encoding=encoding), timedelta(seconds=1))
+            return csp.const(_adapter_payload(kw, encoding), timedelta(seconds=1))
         else:
             raise ValueError("This should never be hit")
 
@@ -392,13 +413,13 @@ def test_kafka_read_write_filter_write(mock_object, my_flag):
     def mock_subscribe(*a, **kw):
         if kw["topic"] == "kafka_topic1" and kw["key"] == "kafka_key":
             encoding = orjson.dumps({"foo": 9.1}).decode()
-            return csp.const(EncodedEngineCycle(encoding=encoding))
+            return csp.const(_adapter_payload(kw, encoding))
         elif kw["topic"] == "kafka_topic1" and kw["key"] == "kafka_key2":
             encoding = orjson.dumps([{"foo": 0.1}, {"my_flag": my_flag}]).decode()
-            return csp.const(EncodedEngineCycle(encoding=encoding), timedelta(seconds=1))
+            return csp.const(_adapter_payload(kw, encoding), timedelta(seconds=1))
         elif kw["topic"] == "kafka_topic2" and kw["key"] == "kafka_key":
             encoding = orjson.dumps({"arr": [7.2, -1001.3]}).decode()
-            return csp.const(EncodedEngineCycle(encoding=encoding), timedelta(seconds=1))
+            return csp.const(_adapter_payload(kw, encoding), timedelta(seconds=1))
         else:
             raise ValueError("This should never be hit")
 
@@ -452,15 +473,13 @@ def test_kafka_read_write_filter_read(mock_object, encoding_with_engine_timestam
         if kw["topic"] == "kafka_topic1" and kw["key"] == "kafka_key":
             # If Kafka publishes to this key on this topic, we capture it
             # with a print statement.
-            if encoding_with_engine_timestamps:
-                csp.print("val_check", kw["x"].encoding)
-            else:
-                csp.print("val_check", kw["x"])
+            # Published messages are raw text on both paths now.
+            csp.print("val_check", kw["x"])
 
     mock_publish = mock.MagicMock(side_effect=mock_publish_action)
 
     def mock_subscribe(*a, **kw):
-        return csp.null_ts(EncodedEngineCycle)
+        return csp.null_ts(kw["ts_type"])
 
     mock_object.return_value.subscribe.side_effect = mock_subscribe
     mock_object.return_value.publish = mock_publish
@@ -506,9 +525,10 @@ def test_kafka_read_write_filter_read(mock_object, encoding_with_engine_timestam
     assert topic_and_call_args["topic"]["kafka_topic1"] == 2
     assert topic_and_call_args["topic"]["kafka_topic2"] == 1
     captured = capsys.readouterr()
+    published = _published_encodings(captured.out)
     if filter_key == "kafka_key":
-        assert captured.out.count('"foo":1.0') == 2
-        assert captured.out.count('"foo":99.0') == 0
+        assert published.count('"foo":1.0') == 2
+        assert published.count('"foo":99.0') == 0
     else:
-        assert captured.out.count('"foo":1.0') == 0
-        assert captured.out.count('"foo":99.0') == 2
+        assert published.count('"foo":1.0') == 0
+        assert published.count('"foo":99.0') == 2

--- a/csp_gateway/tests/server/modules/test_mirror.py
+++ b/csp_gateway/tests/server/modules/test_mirror.py
@@ -9,7 +9,6 @@ import pytest
 from csp_gateway import ReadWriteMode, State
 from csp_gateway.server import (
     ChannelSelection,
-    EncodedEngineCycle,
     Mirror,
     ReplayEngineJSON,
 )
@@ -41,7 +40,7 @@ def test_kafka_engine_replay_read_and_write_read(mock_object, read_write_mode):
     mock_publish = mock.MagicMock()
 
     def mock_subscribe(*a, **kw):
-        return csp.null_ts(EncodedEngineCycle)
+        return csp.null_ts(str)
 
     mock_object.return_value.subscribe.side_effect = mock_subscribe
     mock_object.return_value.publish = mock_publish


### PR DESCRIPTION
`EncodedEngineCycle` is now a pydantic model, and the Kafka module frames its own messages instead of going through csp's `JSONTextMessageMapper`.

## What moved

| call site | before | after |
|---|---|---|
| `json.py` file replay | `csp.Struct` on a `ts[]` | pydantic model |
| `engine_replay.py` interface | `csp.Struct` | pydantic model |
| `ReadWriteKafka` publish | JSON mapper + struct + `field_map` | `RawTextMessageMapper`, we encode |
| `ReadWriteKafka` subscribe, raw path | struct with `field_map={"": "encoding"}` | `ts_type=str` |
| `ReplayEngineKafka` subscribe/publish | JSON mapper + struct | `RawTextMessageMapper`, we encode/decode |
| `ReadWriteKafka` subscribe, engine-timestamp path | JSON mapper + struct | **unchanged** |

`csp.Struct` now appears once in the package, module-private to the Kafka adapter.

## Why one is left

That last row passes `tick_timestamp_from_field`, which makes csp replay each message at the engine time recorded *inside* the payload. csp — not us — has to read that field out, and per its own docstring it can only do that into a struct field:

> `tick_timestamp_from_field`: Override engine tick time using **this struct field**. Only applies during sim replay

Hand csp opaque bytes and it can only fall back to the broker timestamp, and it can't be fixed downstream either: a csp node cannot retroactively move a tick to an earlier engine time. I checked the alternatives — `meta_field_map={"timestamp": ...}` gives the Kafka timestamp rather than the encoded one, and csp's `publish()` exposes no way to set the message timestamp at produce time.

The module already encoded this coupling:

```python
if self.subscribe_with_csp_engine_timestamp and not self.encoding_with_engine_timestamps:
    raise ValueError(...)
```

`TODO_CSP.md` (untracked) writes up the upstream change that would remove the last struct.

## Wire compatibility

Since one subscribe path still parses with csp's mapper, our hand-written framing has to match it byte for byte. That's pinned from csp's source rather than assumed:

```cpp
// JSONMessageWriter.h
case utils::DateTimeWireType::UINT64_MILLIS:  return ( uint64_t ) value.asMilliseconds();
// JSONMessageStructConverter.cpp
case DateTimeWireType::UINT64_MILLIS:  dt = DateTime::fromMilliseconds( raw ); break;
```

So the envelope is `{"encoding": <str>, "csp_timestamp": <int epoch millis>}`, symmetric on read and write, and unchanged from what this code already produced. `test_envelope.py` pins the field names, the integer-millis encoding, the round trip, that we can read what csp's mapper would have written, and that a payload containing a colliding `csp_timestamp` key stays nested rather than inlined.

Writing that test caught a real bug: `EncodedEngineCycle`'s fields defaulted to `None` without being declared nullable, so an explicit `None` raised rather than round-tripping.

## Test changes

The Kafka tests mock `KafkaAdapterManager`, so they encode the adapter's contract. The mocks now build whatever `ts_type` the module asked for instead of always returning a struct, and the two publish assertions unwrap the envelope rather than reaching for `.encoding` on an edge.