### PR TITLE
Honour CUSTOM_CSS and CUSTOM_JS in the spaday UI

### DIFF
--- a/csp_gateway/server/web/spaday_ui.py
+++ b/csp_gateway/server/web/spaday_ui.py
@@ -18,7 +18,6 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass, field as _dc_field
-from html import escape
 from typing import TYPE_CHECKING, Any
 
 from pydantic import TypeAdapter
@@ -235,8 +234,8 @@ class GatewayUI:
             return f"{root}{path}"
         return path
 
-    def _custom_assets(self) -> tuple[str, list[str]]:
-        """The configured `Settings.CUSTOM_CSS` / `CUSTOM_JS` as head markup and script URLs.
+    def _custom_assets(self) -> tuple[list[str], list[str]]:
+        """The configured `Settings.CUSTOM_CSS` / `CUSTOM_JS` as stylesheet and script URLs.
 
         Both are resolved by `GatewayWebApp._resolve_ui_assets` first, so local paths have already
         been mounted and turned into URLs, and anything discovered under ``CUSTOM_STATIC_DIR`` is
@@ -244,9 +243,9 @@ class GatewayUI:
         tags the default UI emits.
         """
         ui_config = getattr(self._web_app, "_ui_config_raw", None) or {}
-        links = "".join(f'<link rel="stylesheet" href="{escape(self.url(href), quote=True)}">' for href in ui_config.get("customCss") or [])
+        stylesheets = [self.url(href) for href in ui_config.get("customCss") or []]
         scripts = [self.url(src) for src in ui_config.get("customJs") or []]
-        return links, scripts
+        return stylesheets, scripts
 
     def _region(self, region: Region, *builtin: Any) -> list[Any]:
         """The composed, order-sorted components for a region.
@@ -735,7 +734,9 @@ class GatewayUI:
             routes=routes,
             store={"dark": False, **self._store_seeds},
             # Custom CSS last so a downstream stylesheet can override the shell theme.
-            head=THEME_CSS + custom_css,
+            # spaday emits these ahead of `head`, so the shell theme still wins a specificity tie.
+            head=THEME_CSS,
+            stylesheets=custom_css,
             scripts=custom_scripts,
             title=title,
             prefix=root,

--- a/csp_gateway/server/web/spaday_ui.py
+++ b/csp_gateway/server/web/spaday_ui.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass, field as _dc_field
+from html import escape
 from typing import TYPE_CHECKING, Any
 
 from pydantic import TypeAdapter
@@ -233,6 +234,19 @@ class GatewayUI:
         if root and path and path.startswith("/"):
             return f"{root}{path}"
         return path
+
+    def _custom_assets(self) -> tuple[str, list[str]]:
+        """The configured `Settings.CUSTOM_CSS` / `CUSTOM_JS` as head markup and script URLs.
+
+        Both are resolved by `GatewayWebApp._resolve_ui_assets` first, so local paths have already
+        been mounted and turned into URLs, and anything discovered under ``CUSTOM_STATIC_DIR`` is
+        included. Scripts are handed to spaday as ES modules rather than the classic ``<script>``
+        tags the default UI emits.
+        """
+        ui_config = getattr(self._web_app, "_ui_config_raw", None) or {}
+        links = "".join(f'<link rel="stylesheet" href="{escape(self.url(href), quote=True)}">' for href in ui_config.get("customCss") or [])
+        scripts = [self.url(src) for src in ui_config.get("customJs") or []]
+        return links, scripts
 
     def _region(self, region: Region, *builtin: Any) -> list[Any]:
         """The composed, order-sorted components for a region.
@@ -691,6 +705,7 @@ class GatewayUI:
         """
         title = getattr(self._settings, "TITLE", "Gateway")
         root = getattr(self._settings, "ROOT_PATH", "") or ""
+        custom_css, custom_scripts = self._custom_assets()
         # spaday's mount() appends plain Starlette routes, which do not carry the FastAPI auth
         # dependencies. Build them on a scratch app under the ROOT_PATH prefix (so the emitted page URLs
         # — /js runtime, wasm — resolve under a proxied sub-path), then re-register with the prefix
@@ -719,7 +734,9 @@ class GatewayUI:
             wire=wire,
             routes=routes,
             store={"dark": False, **self._store_seeds},
-            head=THEME_CSS,
+            # Custom CSS last so a downstream stylesheet can override the shell theme.
+            head=THEME_CSS + custom_css,
+            scripts=custom_scripts,
             title=title,
             prefix=root,
         )

--- a/csp_gateway/tests/server/web/test_ui_customization.py
+++ b/csp_gateway/tests/server/web/test_ui_customization.py
@@ -169,3 +169,48 @@ class TestRootPathNormalization:
             assert '<base href="/watchtower/" />' in client.get("/").text
         finally:
             gateway.stop()
+
+
+class TestSpadayUiCustomization:
+    """The spaday provider must honour the same white-labeling settings as the default UI."""
+
+    def test_custom_css_and_js_are_emitted(self, tmp_path):
+        pytest.importorskip("spaday")
+        client, gateway = _make_client(
+            tmp_path,
+            UI_PROVIDER="spaday",
+            CUSTOM_CSS=["https://cdn.example.com/extra.css"],
+            CUSTOM_JS=["https://cdn.example.com/extra.js"],
+        )
+        try:
+            html = client.get("/").text
+            assert '<link rel="stylesheet" href="https://cdn.example.com/extra.css">' in html
+            # spaday loads extra scripts as ES modules from its bootstrap module.
+            assert 'import "https://cdn.example.com/extra.js";' in html
+        finally:
+            gateway.stop()
+
+    def test_custom_static_dir_is_emitted(self, tmp_path):
+        pytest.importorskip("spaday")
+        (tmp_path / "a.js").write_text("// js")
+        (tmp_path / "b.css").write_text("/* css */")
+        client, gateway = _make_client(tmp_path, UI_PROVIDER="spaday", CUSTOM_STATIC_DIR=str(tmp_path))
+        try:
+            html = client.get("/").text
+            assert 'href="/custom/b.css"' in html
+            assert 'import "/custom/a.js";' in html
+            assert client.get("/custom/a.js").status_code == 200
+        finally:
+            gateway.stop()
+
+    def test_custom_assets_are_root_path_prefixed(self, tmp_path):
+        pytest.importorskip("spaday")
+        (tmp_path / "a.js").write_text("// js")
+        (tmp_path / "b.css").write_text("/* css */")
+        client, gateway = _make_client(tmp_path, UI_PROVIDER="spaday", ROOT_PATH="watchtower/", CUSTOM_STATIC_DIR=str(tmp_path))
+        try:
+            html = client.get("/").text
+            assert 'href="/watchtower/custom/b.css"' in html
+            assert 'import "/watchtower/custom/a.js";' in html
+        finally:
+            gateway.stop()

--- a/csp_gateway/tests/server/web/test_ui_customization.py
+++ b/csp_gateway/tests/server/web/test_ui_customization.py
@@ -184,7 +184,7 @@ class TestSpadayUiCustomization:
         )
         try:
             html = client.get("/").text
-            assert '<link rel="stylesheet" href="https://cdn.example.com/extra.css">' in html
+            assert '<link rel="stylesheet" href="https://cdn.example.com/extra.css" />' in html
             # spaday loads extra scripts as ES modules from its bootstrap module.
             assert 'import "https://cdn.example.com/extra.js";' in html
         finally:

--- a/docs/wiki/UI.md
+++ b/docs/wiki/UI.md
@@ -57,4 +57,4 @@ gateway:
 
 `UI_PROVIDER` defaults to `default` (the React/Perspective UI); set it to `spaday` to use the spaday frontend. Everything else — modules, the REST API, authentication, and `ROOT_PATH` sub-path serving — behaves the same. Selecting `spaday` without the extra installed raises a clear error at startup.
 
-The white-labeling settings (`TITLE`, `HEADER_LOGO`, `FOOTER_LOGO`, `CUSTOM_CSS`, `CUSTOM_JS`, `CUSTOM_STATIC_DIR`) apply to both providers. One difference: the default UI loads `CUSTOM_JS` as classic `<script>` tags, while spaday imports them as ES modules, so a custom script cannot rely on being in global scope.
+The white-labeling settings (`TITLE`, `HEADER_LOGO`, `FOOTER_LOGO`, `CUSTOM_CSS`, `CUSTOM_JS`, `CUSTOM_STATIC_DIR`) apply to both providers, with two differences under spaday. `CUSTOM_JS` files are imported as ES modules rather than loaded as classic `<script>` tags, so a custom script cannot rely on being in global scope. `CUSTOM_CSS` files are linked ahead of the shell's own theme, so overriding a shell style needs a more specific selector rather than relying on source order.

--- a/docs/wiki/UI.md
+++ b/docs/wiki/UI.md
@@ -56,3 +56,5 @@ gateway:
 ```
 
 `UI_PROVIDER` defaults to `default` (the React/Perspective UI); set it to `spaday` to use the spaday frontend. Everything else — modules, the REST API, authentication, and `ROOT_PATH` sub-path serving — behaves the same. Selecting `spaday` without the extra installed raises a clear error at startup.
+
+The white-labeling settings (`TITLE`, `HEADER_LOGO`, `FOOTER_LOGO`, `CUSTOM_CSS`, `CUSTOM_JS`, `CUSTOM_STATIC_DIR`) apply to both providers. One difference: the default UI loads `CUSTOM_JS` as classic `<script>` tags, while spaday imports them as ES modules, so a custom script cannot rely on being in global scope.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,11 +117,10 @@ client = [
 ]
 spaday = [
     # Optional spaday-based frontend provider (Settings.UI_PROVIDER = "spaday")
-    # 0.5 splits the component libraries into their own distributions and adds the `Each` repeater the
-    # staging panel renders with.
-    "spaday>=0.5.0",
-    "spaday-perspective>=0.1.0",
-    "spaday-webawesome>=0.1.0",
+    # 0.7.1 ships the shell's dark palette and the nonce-stamped `stylesheets=` mount option.
+    "spaday>=0.7.1",
+    "spaday-perspective>=0.2.0",
+    "spaday-webawesome>=0.2.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
The spaday provider already read HEADER_LOGO and FOOTER_LOGO from the resolved UI config, but ignored CUSTOM_CSS and CUSTOM_JS, so white-labeling was only partially supported there.

Reuse GatewayWebApp._resolve_ui_assets output rather than re-reading Settings, so local-file mounting and CUSTOM_STATIC_DIR discovery are shared with the default UI, and prefix the URLs with ROOT_PATH at page-build time.

Stylesheets are appended to the spaday head after the shell theme so they can override it; scripts are passed to spaday's scripts= option, which imports them as ES modules rather than the classic script tags the default UI emits.