### PR TITLE
Use spaday's shell palette instead of a hand-rolled one

### DIFF
--- a/csp_gateway/server/web/spaday_ui.py
+++ b/csp_gateway/server/web/spaday_ui.py
@@ -81,22 +81,14 @@ log = logging.getLogger(__name__)
 _ANONYMOUS_TENANT = "__anonymous__"
 
 
-# Minimal shell theming so the spaday page looks reasonable in both light and dark modes.
-# Keyed off the ``wa-dark`` class that ``App().bind_root_class("wa-dark", "dark")`` toggles.
-THEME_CSS = """<style>
+# Page-level resets that spaday's document template does not ship. The palette is deliberately absent:
+# the shell supplies its own light and dark values for the ``spa-*`` tokens, keyed off the ``wa-dark``
+# class that ``App().bind_root_class("wa-dark", "dark")`` toggles, and WebAwesome sets the matching
+# ``color-scheme`` so the page canvas follows.
+PAGE_CSS = """<style>
       html, body { height: 100%; }
       body { margin: 0; font-family: system-ui, sans-serif; }
-      spa-app { --spa-gap: 0.75rem; height: 100vh; }
-      html:not(.wa-dark) { background: #eef1f5; }
-      html:not(.wa-dark) spa-app {
-        --spa-surface: #ffffff; --spa-surface-2: #f3f5f8; --spa-border: #dde3ec; --spa-muted: #5a6a80;
-        color: #1a2230; background: #eef1f5;
-      }
-      html.wa-dark { background: #1b222e; }
-      html.wa-dark spa-app {
-        --spa-surface: #222b39; --spa-surface-2: #2a3445; --spa-border: #3b4860; --spa-muted: #8fa3c0;
-        color: #e6eefb; background: #1b222e;
-      }
+      spa-app { --spa-gap: 0.75rem; }
     </style>"""
 
 
@@ -733,11 +725,11 @@ class GatewayUI:
             wire=wire,
             routes=routes,
             store={"dark": False, **self._store_seeds},
-            # Custom CSS last so a downstream stylesheet can override the shell theme.
-            # spaday emits these ahead of `head`, so the shell theme still wins a specificity tie.
-            head=THEME_CSS,
+            # Emitted after the component packages' own CSS, so a custom stylesheet can override the
+            # shell palette, and before `head`, which carries only document resets.
             stylesheets=custom_css,
             scripts=custom_scripts,
+            head=PAGE_CSS,
             title=title,
             prefix=root,
         )

--- a/docs/wiki/UI.md
+++ b/docs/wiki/UI.md
@@ -57,4 +57,13 @@ gateway:
 
 `UI_PROVIDER` defaults to `default` (the React/Perspective UI); set it to `spaday` to use the spaday frontend. Everything else — modules, the REST API, authentication, and `ROOT_PATH` sub-path serving — behaves the same. Selecting `spaday` without the extra installed raises a clear error at startup.
 
-The white-labeling settings (`TITLE`, `HEADER_LOGO`, `FOOTER_LOGO`, `CUSTOM_CSS`, `CUSTOM_JS`, `CUSTOM_STATIC_DIR`) apply to both providers, with two differences under spaday. `CUSTOM_JS` files are imported as ES modules rather than loaded as classic `<script>` tags, so a custom script cannot rely on being in global scope. `CUSTOM_CSS` files are linked ahead of the shell's own theme, so overriding a shell style needs a more specific selector rather than relying on source order.
+The white-labeling settings (`TITLE`, `HEADER_LOGO`, `FOOTER_LOGO`, `CUSTOM_CSS`, `CUSTOM_JS`, `CUSTOM_STATIC_DIR`) apply to both providers, with one difference under spaday: `CUSTOM_JS` files are imported as ES modules rather than loaded as classic `<script>` tags, so a custom script cannot rely on being in global scope.
+
+The spaday UI takes its colours from the shell's own light and dark palettes, which are published as the `--spa-surface`, `--spa-surface-2`, `--spa-border` and `--spa-muted` custom properties at zero specificity. A `CUSTOM_CSS` file is linked after them, so redefining those properties is enough to rebrand the chrome:
+
+```css
+spa-app { --spa-surface: #ffffff; --spa-border: #dde3ec; }
+html.wa-dark spa-app { --spa-surface: #222b39; --spa-border: #3b4860; }
+```
+
+Component internals are shadow DOM and cannot be selected from an external stylesheet, so restyling those means setting the WebAwesome custom properties they document rather than writing rules against their markup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,8 @@ client = [
 ]
 spaday = [
     # Optional spaday-based frontend provider (Settings.UI_PROVIDER = "spaday")
-    # 0.7.1 ships the shell's dark palette and the nonce-stamped `stylesheets=` mount option.
+    # 0.7.1 ships the shell's own light and dark palettes, which the provider relies on rather than
+    # supplying its own, and the nonce-stamped `stylesheets=` mount option.
     "spaday>=0.7.1",
     "spaday-perspective>=0.2.0",
     "spaday-webawesome>=0.2.0",


### PR DESCRIPTION
The spaday provider shipped its own light and dark values for the `spa-*` shell tokens, because the shell had none of its own and otherwise rendered light chrome on a dark page.

spaday 0.7.1 ships both palettes itself, keyed off the same `wa-dark` class the theme toggle already drives and emitted at zero specificity so an application override still wins:

```css
:where(.wa-dark)  { --spa-surface: #15191e; --spa-surface-2: #1d232b; --spa-border: #333b45; --spa-muted: #9aa3ad; }
:where(.wa-light) { --spa-surface: #fff;    --spa-surface-2: #fafafa; --spa-border: #e6e6e6; --spa-muted: #666; }
```

WebAwesome sets the matching `color-scheme` on the same root class, so the page canvas and text follow without the gateway setting `background` / `color` either.

`THEME_CSS` becomes `PAGE_CSS` and keeps only the document resets spaday's page template does not ship:

```css
html, body { height: 100%; }
body { margin: 0; font-family: system-ui, sans-serif; }
spa-app { --spa-gap: 0.75rem; }
```

`height: 100vh` was dropped from the CSS because `build_page` already applies it inline. Typography is deliberately unchanged — only the palette is being handed over.

This is a visible change: the UI picks up spaday's neutral greys in place of the previous blue-greys.