### PR TITLE
Make spaday the default UI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It is is composed of four major components:
 
 - Engine: [csp](https://github.com/point72/csp), a streaming, complex event processor core
 - API: [FastAPI](https://fastapi.tiangolo.com) REST/WebSocket API
-- UI: [Perspective](https://perspective-dev.github.io/) and React based frontend with automatic table and chart visualizations, with an optional [spaday](https://github.com/1kbgz/spaday)-based frontend
+- UI: [spaday](https://github.com/1kbgz/spaday) and [Perspective](https://perspective-dev.github.io/) based frontend with automatic table and chart visualizations
 - Configuration: [ccflow](https://github.com/point72/ccflow), a [Pydantic](https://docs.pydantic.dev/latest/)/[Hydra](https://hydra.cc) based extensible, composeable dependency injection and configuration framework
 
 For a detailed overview, see our [Documentation](https://github.com/Point72/csp-gateway/wiki/Overview).

--- a/csp_gateway/server/settings.py
+++ b/csp_gateway/server/settings.py
@@ -44,10 +44,10 @@ class Settings(BaseSettings):
     UI: bool = Field(False, description="Enables ui in the web application")
 
     UI_PROVIDER: Literal["default", "spaday"] = Field(
-        "default",
-        description="Frontend provider for the UI. 'default' serves the built-in "
-        "Perspective/React UI; 'spaday' serves a spaday-based UI that mimics it "
-        "(requires the 'spaday' optional dependency).",
+        "spaday",
+        description="Frontend provider for the UI. 'spaday' serves the spaday-based UI; "
+        "'default' serves the legacy Perspective/React UI, which requires the bundled "
+        "Javascript build and is slated for removal.",
     )
 
     # UI customization fields that let downstream applications white-label the

--- a/csp_gateway/server/web/spaday_ui.py
+++ b/csp_gateway/server/web/spaday_ui.py
@@ -1,15 +1,14 @@
 """spaday-based frontend provider for the Gateway web application.
 
-This is the optional alternative to the built-in Perspective/React UI, selected via
-`Settings.UI_PROVIDER == "spaday"`. A `GatewayUI` handle is passed to each module's
-`ui()` hook (mirroring how `GatewayWebApp` is passed to `rest()`); modules register a
+This is the default UI, selected via `Settings.UI_PROVIDER == "spaday"` (the legacy
+Perspective/React frontend remains available as `"default"`). A `GatewayUI` handle is passed to
+each module's `ui()` hook (mirroring how `GatewayWebApp` is passed to `rest()`); modules register a
 main panel or add header actions, and `GatewayUI` assembles a single spaday page and
 mounts it onto the FastAPI app.
 
 This module imports `spaday` at import time, so it is imported only when the spaday provider is
 selected — from `GatewayWebApp` when `UI_PROVIDER == "spaday"`, and lazily from the modules' `ui()`
-hooks (which only run under that provider) — never from `csp_gateway.server.web` at large. It requires
-the optional `spaday` extra (`pip install 'csp-gateway[spaday]'`).
+hooks (which only run under that provider) — never from `csp_gateway.server.web` at large.
 """
 
 from __future__ import annotations
@@ -30,8 +29,8 @@ try:
     import spaday  # noqa: F401
 except ImportError as exc:  # pragma: no cover
     raise ImportError(
-        "The spaday UI provider (Settings.UI_PROVIDER='spaday') requires the optional 'spaday' "
-        "dependency. Install it with: pip install 'csp-gateway[spaday]'."
+        "The spaday UI provider (Settings.UI_PROVIDER='spaday') requires the 'spaday' "
+        "dependency, which ships with csp-gateway. Reinstall it with: pip install csp-gateway."
     ) from exc
 
 from spaday import element

--- a/csp_gateway/tests/server/web/test_staging_panel.py
+++ b/csp_gateway/tests/server/web/test_staging_panel.py
@@ -307,14 +307,14 @@ class TestStagingPanelSharesTheBottomDrawer:
 
 
 class TestStagingPanelDefaultUI:
-    """Under the default (React) provider the module contributes no UI at all."""
+    """Under the legacy (React) provider the module contributes no UI at all."""
 
     @pytest.fixture(scope="class")
     def gateway(self, free_port):
         return Gateway(
             modules=[StagingModule(), MountRestRoutes(force_mount_all=True), MountStagingPanel()],
             channels=StagedChannels(),
-            settings=GatewaySettings(PORT=free_port, UI=True),
+            settings=GatewaySettings(PORT=free_port, UI=True, UI_PROVIDER="default"),
         )
 
     def test_gateway_starts_without_the_spaday_provider(self, gateway):

--- a/csp_gateway/tests/server/web/test_ui_customization.py
+++ b/csp_gateway/tests/server/web/test_ui_customization.py
@@ -12,6 +12,9 @@ from csp_gateway.server.web.app import GatewayWebApp
 
 
 def _make_client(tmp_path, **settings_kwargs) -> TestClient:
+    # These assertions are against the legacy provider's markup, so pin it unless a test asks
+    # for another one.
+    settings_kwargs.setdefault("UI_PROVIDER", "default")
     settings = GatewaySettings(PORT=0, UI=True, **settings_kwargs)
     gateway = Gateway(
         modules=[ExampleModule(), MountControls(), MountRestRoutes(force_mount_all=True)],
@@ -154,7 +157,7 @@ class TestRootPathNormalization:
     def test_normalized_root_path_prefixes_urls(self, tmp_path):
         # A non-leading-slash, trailing-slash value is normalized before use.
         (tmp_path / "logo.svg").write_text("<svg></svg>")
-        settings = GatewaySettings(PORT=0, UI=True, ROOT_PATH="watchtower/", HEADER_LOGO=str(tmp_path / "logo.svg"))
+        settings = GatewaySettings(PORT=0, UI=True, UI_PROVIDER="default", ROOT_PATH="watchtower/", HEADER_LOGO=str(tmp_path / "logo.svg"))
         gateway = Gateway(
             modules=[ExampleModule(), MountControls(), MountRestRoutes(force_mount_all=True)],
             channels=ExampleGatewayChannels(),

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -17,11 +17,3 @@ conda install csp-gateway --channel conda-forge
 ## Source installation
 
 For other platforms and for development installations, [build `csp-gateway` from source](Build-from-Source).
-
-## Optional: spaday UI
-
-To use the optional [spaday](https://github.com/1kbgz/spaday)-based frontend (see [UI](UI)), install the `spaday` extra:
-
-```bash
-pip install 'csp-gateway[spaday]'
-```

--- a/docs/wiki/UI.md
+++ b/docs/wiki/UI.md
@@ -35,17 +35,11 @@ The rightmost top bar button opens the settings drawer. Depending on your server
 - Logs: if your server includes the [`MountOutputsFolder`](MountOutputsFolder) module, this will link to an integrated log and configuration viewer
 - Graph View: if your server includes the [`MountChannelsGraph`](MountChannelsGraph) module, this will link to an integrated graph viewer
 
-## Alternative frontend: spaday
+## Frontend providers
 
-The React/Perspective UI above is the default. `csp-gateway` can optionally serve an alternative frontend built with [spaday](https://github.com/1kbgz/spaday), selected per gateway with the `UI_PROVIDER` setting. It renders the same pieces from the same modules — the Perspective workspace, layout selector, theme toggle, and the settings-drawer actions (shutdown, logs, channels graph, email), plus a "send to a channel" form panel — only the frontend technology differs.
+The UI above is served by [spaday](https://github.com/1kbgz/spaday), the default frontend provider. The legacy React/Perspective frontend is still available, selected per gateway with the `UI_PROVIDER` setting. Both render the same pieces from the same modules — the Perspective workspace, layout selector, theme toggle, and the settings-drawer actions (shutdown, logs, channels graph, email) — and the spaday provider adds a "send to a channel" form panel.
 
-It is an optional extra (it pulls in the `spaday` dependency):
-
-```bash
-pip install 'csp-gateway[spaday]'
-```
-
-Select it in your gateway configuration:
+Select a provider in your gateway configuration:
 
 ```yaml
 port: 8000
@@ -55,6 +49,6 @@ gateway:
     UI_PROVIDER: spaday
 ```
 
-`UI_PROVIDER` defaults to `default` (the React/Perspective UI); set it to `spaday` to use the spaday frontend. Everything else — modules, the REST API, authentication, and `ROOT_PATH` sub-path serving — behaves the same. Selecting `spaday` without the extra installed raises a clear error at startup.
+`UI_PROVIDER` defaults to `spaday`; set it to `default` for the legacy React/Perspective UI, which requires the bundled Javascript build and is slated for removal. Everything else — modules, the REST API, authentication, and `ROOT_PATH` sub-path serving — behaves the same.
 
 The white-labeling settings (`TITLE`, `HEADER_LOGO`, `FOOTER_LOGO`, `CUSTOM_CSS`, `CUSTOM_JS`, `CUSTOM_STATIC_DIR`) apply to both providers, with two differences under spaday. `CUSTOM_JS` files are imported as ES modules rather than loaded as classic `<script>` tags, so a custom script cannot rely on being in global scope. `CUSTOM_CSS` files are linked ahead of the shell's own theme, so overriding a shell style needs a more specific selector rather than relying on source order.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,6 @@ develop = [
     "pandas",
     "logfire",
     "opentelemetry-instrumentation-fastapi",
-    # spaday UI provider, so its tests are exercised rather than skipped
-    "spaday>=0.7.1",
-    "spaday-perspective>=0.2.0",
-    "spaday-webawesome>=0.2.0",
 ]
 server = [
     "atomic-counter>=0.1.3",
@@ -103,6 +99,10 @@ server = [
     "psutil",
     "pyarrow",
     "pydantic>=2",
+    # Default frontend provider (Settings.UI_PROVIDER = "spaday").
+    "spaday>=0.7.1",
+    "spaday-perspective>=0.2.0",
+    "spaday-webawesome>=0.2.0",
     "uvicorn>=0.28.1,<0.50",
     "uvloop",
     "websockets",
@@ -114,13 +114,6 @@ client = [
     "nest-asyncio",
     "packaging",
     "pydantic>=2",
-]
-spaday = [
-    # Optional spaday-based frontend provider (Settings.UI_PROVIDER = "spaday")
-    # 0.7.1 ships the shell's dark palette and the nonce-stamped `stylesheets=` mount option.
-    "spaday>=0.7.1",
-    "spaday-perspective>=0.2.0",
-    "spaday-webawesome>=0.2.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Makes the spaday provider the default. Every shipped gateway config already sets `UI_PROVIDER: spaday` (`config/gateway/omnibus.yaml`, `demo/config/demo_spaday.yaml`, `demo/config/omnibus_spaday.yaml`) and none selects `default`, so the setting's default was the only thing still pointing at the legacy React frontend.