### PR TITLE
Upgrade to Perspective 5

### DIFF
--- a/csp_gateway/server/modules/web/perspective.py
+++ b/csp_gateway/server/modules/web/perspective.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Iterable
 from datetime import date, datetime, timedelta
 from io import BytesIO
 from logging import getLogger
@@ -285,6 +286,18 @@ class MountPerspectiveTables(GatewayModule):
     default_layout: str | None = Field(
         None,
         description="Default layout to use for all tables if no specific layout is provided.",
+    )
+    default_layout_tables: list[str] = Field(
+        default_factory=list,
+        description="Tables the generated default layout shows, by table name and in this order. "
+        "Empty means the first `default_layout_max_tables` tables in name order. Names that are not "
+        "registered tables are ignored.",
+    )
+    default_layout_max_tables: int = Field(
+        5,
+        description="How many tables the generated default layout shows when `default_layout_tables` "
+        "is not set. Every table is still available to add by hand; this only bounds the generated "
+        "layout, whose tabs get narrower the more it holds.",
     )
 
     @field_validator("layouts")
@@ -675,10 +688,19 @@ class MountPerspectiveTables(GatewayModule):
                 "default_architecture": self.default_architecture,
                 "layouts": self.layouts,
                 "default_layout": self.default_layout,
+                "default_layout_tables": self._select_default_layout_tables(self._get_tables()),
                 "tables": self._get_tables(),
                 "unused_tables": self._unused_tables,
                 "table_sizes": self._get_table_sizes(),
             }
+
+    def _select_default_layout_tables(self, available: Iterable[str]) -> list[str]:
+        """The tables the generated default layout shows, in display order."""
+        names = list(available)
+        if self.default_layout_tables:
+            known = set(names)
+            return [name for name in self.default_layout_tables if name in known]
+        return sorted(names)[: self.default_layout_max_tables]
 
     def ui(self, app: "GatewayUI") -> None:
         # Register the Perspective workspace as the main panel of the spaday UI. Data rides
@@ -687,11 +709,13 @@ class MountPerspectiveTables(GatewayModule):
         from csp_gateway.server.web.spaday_ui import Region
 
         layouts = dict(self._layouts)
+        tables = self._get_tables()
         app.add(
             Region.MAIN,
             app.perspective_panel(
                 route=f"{app.settings.API_STR}{self._route}",
-                tables=list(self._get_tables().keys()),
+                tables=list(tables.keys()),
+                default_tables=self._select_default_layout_tables(tables),
                 layouts=layouts,
             ),
         )

--- a/csp_gateway/server/modules/web/perspective.py
+++ b/csp_gateway/server/modules/web/perspective.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from logging import getLogger
 from typing import (
     TYPE_CHECKING,
+    Any,
     Literal,
     TypeVar,
 )
@@ -153,6 +154,55 @@ class TableConfig(BaseModel):
 # Backwards compat alias
 AdditionalTableConfig = TableConfig
 
+# Perspective 4 stored a workspace layout as a Lumino widget tree (`detail`/`master` of `split-area`
+# and `tab-area` nodes) alongside a `viewers` map. Perspective 5 folded the workspace into
+# `<perspective-viewer>` itself, which takes a `layout` tree of `split-layout`/`tab-layout` nodes and
+# a `panels` map. Per-panel bodies are unchanged -- the viewer migrates those from their own stamped
+# `version` -- so only the envelope is rewritten here.
+_LAYOUT_NODE_TYPES = {"split-area": "split-layout", "tab-area": "tab-layout"}
+
+
+def _migrate_layout_node(node: Any) -> Any:
+    if not isinstance(node, dict):
+        return node
+    node_type = _LAYOUT_NODE_TYPES.get(node.get("type"))
+    if node_type == "tab-layout":
+        migrated = {"type": node_type, "tabs": list(node.get("widgets") or [])}
+        if "currentIndex" in node:
+            migrated["selected"] = node["currentIndex"]
+        return migrated
+    if node_type == "split-layout":
+        return {
+            "type": node_type,
+            "orientation": node.get("orientation", "horizontal"),
+            "sizes": list(node.get("sizes") or []),
+            "children": [_migrate_layout_node(child) for child in node.get("children") or []],
+        }
+    return node
+
+
+def migrate_perspective_layout(layout: str) -> str:
+    """Rewrite a Perspective 4 workspace layout as the Perspective 5 equivalent.
+
+    Layouts already in the version 5 shape, and anything unparseable, are returned untouched so this
+    is safe to apply to every configured layout on every startup.
+    """
+    try:
+        parsed = orjson.loads(layout)
+    except orjson.JSONDecodeError:
+        return layout
+    if not isinstance(parsed, dict) or "viewers" not in parsed:
+        return layout
+
+    migrated: dict[str, Any] = {"panels": parsed.get("viewers") or {}}
+    root = (parsed.get("detail") or {}).get("main")
+    if root is not None:
+        migrated["layout"] = _migrate_layout_node(root)
+    masters = (parsed.get("master") or {}).get("widgets") or []
+    if masters:
+        migrated["masters"] = list(masters)
+    return orjson.dumps(migrated).decode()
+
 
 def _is_channel_selection_input(v) -> bool:
     """Detect whether a raw input value looks like a ChannelSelection (old-style tables field)."""
@@ -236,6 +286,11 @@ class MountPerspectiveTables(GatewayModule):
         None,
         description="Default layout to use for all tables if no specific layout is provided.",
     )
+
+    @field_validator("layouts")
+    @classmethod
+    def _migrate_layouts(cls, layouts: dict[str, str]) -> dict[str, str]:
+        return {name: migrate_perspective_layout(layout) for name, layout in layouts.items()}
 
     update_interval: timedelta = Field(default=timedelta(seconds=2))
     perspective_field: str = Field(
@@ -480,7 +535,8 @@ class MountPerspectiveTables(GatewayModule):
         self._client = self._server.new_local_client()
         self._layouts = self.layouts.copy()
         if self.layouts_field:
-            self._layouts.update(getattr(channels, self.layouts_field))
+            # Not reachable from the field validator, so migrate on the way in.
+            self._layouts.update({name: migrate_perspective_layout(layout) for name, layout in getattr(channels, self.layouts_field).items()})
         self._connect_all_tables(channels)
 
         # Run perspective on background daemon threads

--- a/csp_gateway/server/web/spaday_ui.py
+++ b/csp_gateway/server/web/spaday_ui.py
@@ -396,19 +396,16 @@ class GatewayUI:
 
     @staticmethod
     def _default_layout(tables: list[str]) -> dict[str, Any]:
-        """A perspective-workspace layout that shows every table in its own datagrid tab."""
-        widgets: dict[str, Any] = {}
-        widget_ids: list[str] = []
+        """A perspective workspace config that shows every table in its own datagrid tab."""
+        panels: dict[str, Any] = {}
+        panel_ids: list[str] = []
         for i, table in enumerate(tables):
-            widget_id = f"CSP_GATEWAY_{i}"
-            widgets[widget_id] = {"table": table, "plugin": "Datagrid", "title": table}
-            widget_ids.append(widget_id)
+            panel_id = f"CSP_GATEWAY_{i}"
+            panels[panel_id] = {"table": table, "plugin": "Datagrid", "title": table}
+            panel_ids.append(panel_id)
         return {
-            "sizes": [1],
-            "detail": {"main": {"type": "tab-area", "widgets": widget_ids, "currentIndex": 0}},
-            "master": {"sizes": [], "widgets": []},
-            "mode": "globalFilters",
-            "viewers": widgets,
+            "layout": {"type": "tab-layout", "tabs": panel_ids, "selected": 0},
+            "panels": panels,
         }
 
     def send_panel(self, specs: list[SendSpec]) -> Any:

--- a/csp_gateway/server/web/spaday_ui.py
+++ b/csp_gateway/server/web/spaday_ui.py
@@ -264,15 +264,17 @@ class GatewayUI:
         *,
         route: str,
         tables: list[str] | None = None,
+        default_tables: list[str] | None = None,
         layouts: dict[str, str] | None = None,
     ) -> Any:
         """A Perspective workspace panel (the primary data view), bound to the theme + `view` state.
 
         Data rides Perspective's own websocket at ``route``; the panel only carries the workspace
-        layout/theme config. Add it to `Region.MAIN`.
+        layout/theme config. ``default_tables`` are the ones the generated layout opens, defaulting
+        to all of ``tables``. Add it to `Region.MAIN`.
         """
         tables = list(tables or [])
-        layout_expr: Any = self._default_layout(tables)
+        layout_expr: Any = self._default_layout(list(default_tables) if default_tables is not None else tables)
         for name, layout_json in (layouts or {}).items():
             try:
                 parsed = json.loads(layout_json)

--- a/csp_gateway/tests/server/modules/web/test_perspective.py
+++ b/csp_gateway/tests/server/modules/web/test_perspective.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, date, datetime, timedelta
 from enum import Enum, auto
 from unittest.mock import MagicMock
@@ -20,6 +21,7 @@ from csp_gateway import (
     create_pyarrow_table,
     psp_schema_to_arrow_schema,
 )
+from csp_gateway.server.modules.web.perspective import migrate_perspective_layout
 from csp_gateway.testing.harness import GatewayTestHarness
 
 
@@ -756,3 +758,65 @@ def test_tables_unified_api():
     assert table_len("test_channel_limited") == 3
     # limit_channel has limit=5
     assert table_len("limit_channel") == 5
+
+
+class TestLayoutMigration:
+    """Perspective 4 workspace layouts are rewritten to the Perspective 5 shape."""
+
+    V4_LAYOUT = json.dumps(
+        {
+            "sizes": [1],
+            "detail": {
+                "main": {
+                    "type": "split-area",
+                    "orientation": "vertical",
+                    "sizes": [0.3, 0.7],
+                    "children": [
+                        {"type": "tab-area", "widgets": ["A"], "currentIndex": 0},
+                        {"type": "tab-area", "widgets": ["B", "C"], "currentIndex": 1},
+                    ],
+                }
+            },
+            "master": {"sizes": [], "widgets": ["A"]},
+            "mode": "globalFilters",
+            "viewers": {
+                "A": {"table": "example", "plugin": "Datagrid"},
+                "B": {"table": "example", "plugin": "Treemap"},
+                "C": {"table": "other", "plugin": "Datagrid"},
+            },
+        }
+    )
+
+    def test_widget_tree_becomes_layout_tree(self):
+        migrated = json.loads(migrate_perspective_layout(self.V4_LAYOUT))
+        assert migrated["layout"] == {
+            "type": "split-layout",
+            "orientation": "vertical",
+            "sizes": [0.3, 0.7],
+            "children": [
+                {"type": "tab-layout", "tabs": ["A"], "selected": 0},
+                {"type": "tab-layout", "tabs": ["B", "C"], "selected": 1},
+            ],
+        }
+
+    def test_viewers_become_panels_and_masters_are_kept(self):
+        migrated = json.loads(migrate_perspective_layout(self.V4_LAYOUT))
+        assert sorted(migrated["panels"]) == ["A", "B", "C"]
+        assert migrated["panels"]["B"] == {"table": "example", "plugin": "Treemap"}
+        assert migrated["masters"] == ["A"]
+        # The v4-only envelope keys do not survive.
+        assert "viewers" not in migrated
+        assert "detail" not in migrated
+
+    def test_already_migrated_layout_is_untouched(self):
+        once = migrate_perspective_layout(self.V4_LAYOUT)
+        assert migrate_perspective_layout(once) == once
+
+    @pytest.mark.parametrize("layout", ["", "not json", "[]", '{"panels": {}}'])
+    def test_non_v4_input_passes_through(self, layout):
+        assert migrate_perspective_layout(layout) == layout
+
+    def test_configured_layouts_are_migrated_on_validation(self):
+        module = MountPerspectiveTables(layouts={"Server Defined Layout": self.V4_LAYOUT})
+        migrated = json.loads(module.layouts["Server Defined Layout"])
+        assert sorted(migrated) == ["layout", "masters", "panels"]

--- a/csp_gateway/tests/server/modules/web/test_perspective.py
+++ b/csp_gateway/tests/server/modules/web/test_perspective.py
@@ -820,3 +820,29 @@ class TestLayoutMigration:
         module = MountPerspectiveTables(layouts={"Server Defined Layout": self.V4_LAYOUT})
         migrated = json.loads(module.layouts["Server Defined Layout"])
         assert sorted(migrated) == ["layout", "masters", "panels"]
+
+
+class TestDefaultLayoutTables:
+    """Which tables the generated default layout opens."""
+
+    AVAILABLE = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf"]
+
+    @staticmethod
+    def _module(**kwargs) -> MountPerspectiveTables:
+        return MountPerspectiveTables(**kwargs)
+
+    def test_caps_at_five_in_name_order_by_default(self):
+        module = self._module()
+        assert module._select_default_layout_tables(self.AVAILABLE) == ["alpha", "bravo", "charlie", "delta", "echo"]
+
+    def test_max_is_configurable(self):
+        module = self._module(default_layout_max_tables=2)
+        assert module._select_default_layout_tables(self.AVAILABLE) == ["alpha", "bravo"]
+
+    def test_explicit_tables_win_and_keep_their_order(self):
+        module = self._module(default_layout_tables=["golf", "alpha"], default_layout_max_tables=1)
+        assert module._select_default_layout_tables(self.AVAILABLE) == ["golf", "alpha"]
+
+    def test_unknown_table_names_are_dropped(self):
+        module = self._module(default_layout_tables=["golf", "not_a_table"])
+        assert module._select_default_layout_tables(self.AVAILABLE) == ["golf"]

--- a/csp_gateway/tests/server/web/test_spaday_ui.py
+++ b/csp_gateway/tests/server/web/test_spaday_ui.py
@@ -233,3 +233,17 @@ class TestSpadaySendFormDetails:
         tree = client.get("/tree.json").text
         assert "/api/v1/send/basket" in tree
         assert "send_key_basket" in tree
+
+
+class TestDefaultLayout:
+    """The generated layout is a Perspective 5 whole-element config."""
+
+    def test_one_datagrid_panel_per_table(self):
+        from csp_gateway.server.web.spaday_ui import GatewayUI
+
+        layout = GatewayUI._default_layout(["orders", "fills"])
+        assert layout["layout"] == {"type": "tab-layout", "tabs": ["CSP_GATEWAY_0", "CSP_GATEWAY_1"], "selected": 0}
+        assert layout["panels"] == {
+            "CSP_GATEWAY_0": {"table": "orders", "plugin": "Datagrid", "title": "orders"},
+            "CSP_GATEWAY_1": {"table": "fills", "plugin": "Datagrid", "title": "fills"},
+        }

--- a/js/package.json
+++ b/js/package.json
@@ -21,13 +21,12 @@
     "react-modern-drawer": "^1.4.0"
   },
   "devDependencies": {
-    "@perspective-dev/client": "~4.5.1",
-    "@perspective-dev/react": "~4.5.1",
-    "@perspective-dev/server": "~4.5.1",
-    "@perspective-dev/viewer": "~4.5.1",
-    "@perspective-dev/viewer-charts": "~4.5.1",
-    "@perspective-dev/viewer-datagrid": "~4.5.1",
-    "@perspective-dev/workspace": "~4.5.1",
+    "@perspective-dev/client": "~5.2.0",
+    "@perspective-dev/react": "~5.2.0",
+    "@perspective-dev/server": "~5.2.0",
+    "@perspective-dev/viewer": "~5.2.0",
+    "@perspective-dev/viewer-charts": "~5.2.0",
+    "@perspective-dev/viewer-datagrid": "~5.2.0",
     "cpy": "^13.2.2",
     "esbuild": "^0.28.0",
     "lightningcss": "^1.29.3",
@@ -37,13 +36,12 @@
     "react-dom": "19.2.6"
   },
   "peerDependencies": {
-    "@perspective-dev/client": "~4.5.1",
-    "@perspective-dev/react": "~4.5.1",
-    "@perspective-dev/server": "~4.5.1",
-    "@perspective-dev/viewer": "~4.5.1",
-    "@perspective-dev/viewer-charts": "~4.5.1",
-    "@perspective-dev/viewer-datagrid": "~4.5.1",
-    "@perspective-dev/workspace": "~4.5.1",
+    "@perspective-dev/client": "~5.2.0",
+    "@perspective-dev/react": "~5.2.0",
+    "@perspective-dev/server": "~5.2.0",
+    "@perspective-dev/viewer": "~5.2.0",
+    "@perspective-dev/viewer-charts": "~5.2.0",
+    "@perspective-dev/viewer-datagrid": "~5.2.0",
     "react": "19.2.6",
     "react-dom": "19.2.6"
   }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -20,26 +20,23 @@ importers:
         version: 1.4.0(react@19.2.6)
     devDependencies:
       '@perspective-dev/client':
-        specifier: ~4.5.1
-        version: 4.5.1
+        specifier: ~5.2.0
+        version: 5.2.0
       '@perspective-dev/react':
-        specifier: ~4.5.1
-        version: 4.5.1
+        specifier: ~5.2.0
+        version: 5.2.0
       '@perspective-dev/server':
-        specifier: ~4.5.1
-        version: 4.5.1
+        specifier: ~5.2.0
+        version: 5.2.0
       '@perspective-dev/viewer':
-        specifier: ~4.5.1
-        version: 4.5.1
+        specifier: ~5.2.0
+        version: 5.2.0
       '@perspective-dev/viewer-charts':
-        specifier: ~4.5.1
-        version: 4.5.1
+        specifier: ~5.2.0
+        version: 5.2.0
       '@perspective-dev/viewer-datagrid':
-        specifier: ~4.5.1
-        version: 4.5.1
-      '@perspective-dev/workspace':
-        specifier: ~4.5.1
-        version: 4.5.1
+        specifier: ~5.2.0
+        version: 5.2.0
       cpy:
         specifier: ^13.2.2
         version: 13.2.2
@@ -220,45 +217,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@lumino/algorithm@2.0.4':
-    resolution: {integrity: sha512-gddBhESPqu25KWLeAK9Kz8tS9Ph7P45i0CNG7Ia4XMhK9PHLtTsBdJTC9jP+MqhbzC8zDT/4ekvYRV9ojRPj7Q==}
-
-  '@lumino/collections@2.0.4':
-    resolution: {integrity: sha512-D/Py9L5HET6+XUYGxFqDEEth4B65X2c7B/GQVRR8q5Fl7EArVL6e98ZXw8BMkuPcTNa0zlENpCKXzlcoJZxXgQ==}
-
-  '@lumino/commands@2.3.3':
-    resolution: {integrity: sha512-7Ci0QdFzt4NKFMhULr19sJPpOLHJw/oYlq6Pb0/Kq1s05+cIoLimr5wiyjkbAlNoGO/8A8SEBGHy3uctZz6G3A==}
-
-  '@lumino/coreutils@2.2.2':
-    resolution: {integrity: sha512-zaKJaK7rawPATn2BGHkbMrR6oK3s9PxNe9KreLwWF2dB4ZBHDiEmNLRyHRorfJ7XqVOEXAsAAj0jFn+qJPC/4Q==}
-
-  '@lumino/disposable@2.1.5':
-    resolution: {integrity: sha512-hO9AkJK0oEGzxopuxI8LaZqwzSNwXJTGCdr5K4gh6al+zxpN7rOCh6Aq3zDxkIHJU4zybxv8r02ardx9XJsG3A==}
-
-  '@lumino/domutils@2.0.4':
-    resolution: {integrity: sha512-naYGUQn3e0CLtz/tjKOZP8SOBg0SW7EguhkxLpNUXlVUvx7rVsfr0VI22FVL+jgI0FbxXpEkxpSMxtK73jxJAg==}
-
-  '@lumino/dragdrop@2.1.8':
-    resolution: {integrity: sha512-5sBYkTka598+XsgjY2tWOC+WYCh9NEgx8RhLvQ3x+V182YhcpEXw38RWGQZyNpQ4m4vtQWKv42A26q+ae6sMwg==}
-
-  '@lumino/keyboard@2.0.4':
-    resolution: {integrity: sha512-kIVkdSz8F5wtZr8hZp0CMX+E0eMCOnFH6XCT7j2UBQ80ERJHFy0eX+IbNo3dtRQ7+CcDhBV4hQquFNFa+/04QQ==}
-
-  '@lumino/messaging@2.0.4':
-    resolution: {integrity: sha512-NbZnchAPOciSe9Qn/g6EzG0LRaw7bygFIXbCD440ZhzvugdBeAerwYhrA795jkXPNrrl3olp5AlO0cBB/XZNtg==}
-
-  '@lumino/properties@2.0.4':
-    resolution: {integrity: sha512-XsL2qLZk+1FbfuTrkyjciI8PMDw3YcaBkqVQ+iv7OOJf9bUlrmTpCMY0Hu5d3hV2W3TWlRsdbvRRLEBJSKv0iA==}
-
-  '@lumino/signaling@2.1.5':
-    resolution: {integrity: sha512-Wkx6WR45ynmKBlW0GBEoh4xk9+QluKr1JHuMftqcStBHSQBCnN54UKRRDbySXHGRhhx6p4neu7sGomgQSlQK8w==}
-
-  '@lumino/virtualdom@2.0.4':
-    resolution: {integrity: sha512-7MFthA9KUsqZTGm/D98FZt1QupjIGyd3XyB4SIugn6DQAqhjBiyykCZydnRq3qmuMHybQel33dNIbHpzyNyQwA==}
-
-  '@lumino/widgets@2.7.5':
-    resolution: {integrity: sha512-i11PlbTsZYIvC/uhcC4FeeLnu/7vveG8WzXFbxPunjT1yGjleqQIPlpMOAJ5d4PwCKqeM8LYttYke6ZOXvXDLA==}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -271,26 +229,23 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@perspective-dev/client@4.5.1':
-    resolution: {integrity: sha512-Yb/huLDHEQ9FFeTloipHKM2oVtgTkHLIEqh971eznOc0sNQGg9Sd7flju8xlKe8KMGe3VCo7/wlvxr4GqBi1Bw==}
+  '@perspective-dev/client@5.2.0':
+    resolution: {integrity: sha512-zkJmJFwdw0wMREoJt8gUJyCsflzi7s7Yc8ZtUCOLE9XB6fdyxJmDB99cxO3Q+hno/57kLsz8VNoz8XSm6PZNrg==}
 
-  '@perspective-dev/react@4.5.1':
-    resolution: {integrity: sha512-GIQIzMS/06HO0gMh46MUVwnezw32OtpbNCY7SiM7PSVUVe4v/AXiBytiSPlbWfD7j+Zh5QRh2o1z41Rx7D5h6Q==}
+  '@perspective-dev/react@5.2.0':
+    resolution: {integrity: sha512-sTurmFFUtPytI3QZ9bH/dy89C6DEi5L3NqVO32ODbPZx+69woNcBbAyVkWSpLZBt0UUq2kzWlIuHuq9Yeh66HQ==}
 
-  '@perspective-dev/server@4.5.1':
-    resolution: {integrity: sha512-VzR1Z+SdUlB4K1hTHFxVE7PLxFXtTb008fBGMg/uo3Y3qDbJh/9IcZjOwvpI86k6QUZ49VR2w3BDGdh7YzF/8A==}
+  '@perspective-dev/server@5.2.0':
+    resolution: {integrity: sha512-WRBiokT2/BYM8Ipe7Dg1/2UYNb01Vsox79KBfFVI800VmwdId0GdqI95zufN5ZoFffeBfri1sr3S3AShBRFXKA==}
 
-  '@perspective-dev/viewer-charts@4.5.1':
-    resolution: {integrity: sha512-O4M45uav+zhommqEQJs05lc2G9/OvAIBUYux04s6TP5zxEuCCZjfAfCJKVLB4rTIeZJGES+lcXoCahktFCMLZg==}
+  '@perspective-dev/viewer-charts@5.2.0':
+    resolution: {integrity: sha512-Gf0Vw4GmPU73d8r1jCxBQ/pAz1G2fbon3JIPU9BQI/Godz3l0MwrsMVicPgp/iLKHd6NU4l82KFRGDTBJVdbBQ==}
 
-  '@perspective-dev/viewer-datagrid@4.5.1':
-    resolution: {integrity: sha512-MQyAzigizk32zgZori/8jbWptRJ2UQATi8XaBO9xTcSarr0noDsPp1wxHIDOCSkxoX+0LBOkro+LmQ5AAnLWgw==}
+  '@perspective-dev/viewer-datagrid@5.2.0':
+    resolution: {integrity: sha512-v/SR/35YfyKfivO21nglJFiyG1iE5G8vMwIwWI6fQuwjW764pmNrm/zcrNWNY70x5XHkPRM94aY6LjkLsLkO2g==}
 
-  '@perspective-dev/viewer@4.5.1':
-    resolution: {integrity: sha512-dILBJOlVKwIXwTFkwSJL9ZBk1QQKKnQrgg9CBCZCJEiqe2+ApgW0UlT1XzCCK4uuwHAVHtBaNow237iDqWSf3A==}
-
-  '@perspective-dev/workspace@4.5.1':
-    resolution: {integrity: sha512-9hVsVHu6sKwRQkP2ChmIlI/W6ieA2Mr49OiSHVSicEw28INbMZgaEU/Pn21pIsg0S+VOgxcu/b07f37GajSecA==}
+  '@perspective-dev/viewer@5.2.0':
+    resolution: {integrity: sha512-IIyqdPduofzzZ/QWrteq29IadJQR8IapTRz7U6XbrtBBm7eyiFsIBKQV0wFfcqWg4TRnhuvCAUvBRieuE0R8Eg==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -767,24 +722,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -805,9 +764,6 @@ packages:
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
-
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -969,8 +925,11 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
-  regular-table@0.8.4:
-    resolution: {integrity: sha512-VmV3kxmkXX0BehXSFBeF6FMBqyYdciY6d/wI6/5hvXomH7K9nfGASOmitF3WeLsL9eiiattwR+o3tcu4En/Xaw==}
+  regular-layout@0.6.1:
+    resolution: {integrity: sha512-vGDEFACgFbS/d5kLWJ6AMWY/3DYaZoF1P8+y4KIDnPUFqUQgV5bV8avX7836izmexfmz6ik8JZ4V0Xo4FhaZGQ==}
+
+  regular-table@0.8.6:
+    resolution: {integrity: sha512-jzJzu9WLtqwMgbf5ak/VdNm/YLHUDnDSCHD5SOksnHrHLuDN6l5i2stYfe7BjsHbQV1Gx9369Ma40nTBCgOFvA==}
     engines: {node: '>=16'}
 
   requires-port@1.0.0:
@@ -1275,69 +1234,6 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@lumino/algorithm@2.0.4': {}
-
-  '@lumino/collections@2.0.4':
-    dependencies:
-      '@lumino/algorithm': 2.0.4
-
-  '@lumino/commands@2.3.3':
-    dependencies:
-      '@lumino/algorithm': 2.0.4
-      '@lumino/coreutils': 2.2.2
-      '@lumino/disposable': 2.1.5
-      '@lumino/domutils': 2.0.4
-      '@lumino/keyboard': 2.0.4
-      '@lumino/signaling': 2.1.5
-      '@lumino/virtualdom': 2.0.4
-
-  '@lumino/coreutils@2.2.2':
-    dependencies:
-      '@lumino/algorithm': 2.0.4
-
-  '@lumino/disposable@2.1.5':
-    dependencies:
-      '@lumino/signaling': 2.1.5
-
-  '@lumino/domutils@2.0.4': {}
-
-  '@lumino/dragdrop@2.1.8':
-    dependencies:
-      '@lumino/coreutils': 2.2.2
-      '@lumino/disposable': 2.1.5
-
-  '@lumino/keyboard@2.0.4': {}
-
-  '@lumino/messaging@2.0.4':
-    dependencies:
-      '@lumino/algorithm': 2.0.4
-      '@lumino/collections': 2.0.4
-
-  '@lumino/properties@2.0.4': {}
-
-  '@lumino/signaling@2.1.5':
-    dependencies:
-      '@lumino/algorithm': 2.0.4
-      '@lumino/coreutils': 2.2.2
-
-  '@lumino/virtualdom@2.0.4':
-    dependencies:
-      '@lumino/algorithm': 2.0.4
-
-  '@lumino/widgets@2.7.5':
-    dependencies:
-      '@lumino/algorithm': 2.0.4
-      '@lumino/commands': 2.3.3
-      '@lumino/coreutils': 2.2.2
-      '@lumino/disposable': 2.1.5
-      '@lumino/domutils': 2.0.4
-      '@lumino/dragdrop': 2.1.8
-      '@lumino/keyboard': 2.0.4
-      '@lumino/messaging': 2.0.4
-      '@lumino/properties': 2.0.4
-      '@lumino/signaling': 2.1.5
-      '@lumino/virtualdom': 2.0.4
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1350,9 +1246,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@perspective-dev/client@4.5.1':
+  '@perspective-dev/client@5.2.0':
     dependencies:
-      '@perspective-dev/server': 4.5.1
+      '@perspective-dev/server': 5.2.0
       pro_self_extracting_wasm: 0.0.9
       stoppable: 1.1.0
       ws: 8.20.1
@@ -1362,11 +1258,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@perspective-dev/react@4.5.1':
+  '@perspective-dev/react@5.2.0':
     dependencies:
-      '@perspective-dev/client': 4.5.1
-      '@perspective-dev/viewer': 4.5.1
-      '@perspective-dev/workspace': 4.5.1
+      '@perspective-dev/client': 5.2.0
+      '@perspective-dev/viewer': 5.2.0
       '@types/react': 19.2.15
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -1376,43 +1271,26 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@perspective-dev/server@4.5.1': {}
+  '@perspective-dev/server@5.2.0': {}
 
-  '@perspective-dev/viewer-charts@4.5.1': {}
+  '@perspective-dev/viewer-charts@5.2.0': {}
 
-  '@perspective-dev/viewer-datagrid@4.5.1':
+  '@perspective-dev/viewer-datagrid@5.2.0':
     dependencies:
-      '@perspective-dev/client': 4.5.1
-      '@perspective-dev/viewer': 4.5.1
-      regular-table: 0.8.4
+      '@perspective-dev/client': 5.2.0
+      '@perspective-dev/viewer': 5.2.0
+      regular-table: 0.8.6
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@perspective-dev/viewer@4.5.1':
+  '@perspective-dev/viewer@5.2.0':
     dependencies:
-      '@perspective-dev/client': 4.5.1
+      '@perspective-dev/client': 5.2.0
       pro_self_extracting_wasm: 0.0.9
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
-  '@perspective-dev/workspace@4.5.1':
-    dependencies:
-      '@lumino/algorithm': 2.0.4
-      '@lumino/commands': 2.3.3
-      '@lumino/coreutils': 2.2.2
-      '@lumino/domutils': 2.0.4
-      '@lumino/messaging': 2.0.4
-      '@lumino/signaling': 2.1.5
-      '@lumino/virtualdom': 2.0.4
-      '@lumino/widgets': 2.7.5
-      '@perspective-dev/client': 4.5.1
-      lodash: 4.18.1
+      regular-layout: 0.6.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -2037,8 +1915,6 @@ snapshots:
       pify: 3.0.0
       strip-bom: 3.0.0
 
-  lodash@4.18.1: {}
-
   math-intrinsics@1.1.0: {}
 
   memorystream@0.3.1: {}
@@ -2200,7 +2076,9 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  regular-table@0.8.4: {}
+  regular-layout@0.6.1: {}
+
+  regular-table@0.8.6: {}
 
   requires-port@1.0.0: {}
 

--- a/js/src/css/perspective.css
+++ b/js/src/css/perspective.css
@@ -1,5 +1,7 @@
 /* Dark */
-[data-theme="dark"] perspective-workspace[theme="Pro Dark"],
+/* Perspective 5 hosts the multi-panel layout on <perspective-viewer> itself, so the top-level
+   element selectors below address it by id rather than the removed <perspective-workspace>. */
+[data-theme="dark"] perspective-viewer#workspace[theme="Pro Dark"],
 [data-theme="dark"] perspective-indicator[theme="Pro Dark"] {
   --psp-theme-name: "Pro Dark";
 }
@@ -47,7 +49,7 @@
   --settings-button--margin: 10px 0 0 0;
 }
 
-[data-theme="dark"] perspective-workspace {
+[data-theme="dark"] perspective-viewer#workspace {
   font-family: "Roboto Mono";
   --open-settings-button--content: "expand_more";
   --close-settings-button--content: "expand_less";
@@ -124,14 +126,19 @@
 }
 
 /* Light */
-perspective-workspace,
-perspective-workspace[theme="Pro Light"],
+perspective-viewer#workspace,
+perspective-viewer#workspace[theme="Pro Light"],
 perspective-indicator[theme="Pro Light"] {
   --psp-theme-name: "Pro Light";
-  flex-grow: 1;
 }
 
-perspective-workspace {
+/* The workspace fills the flex column between the header and footer. */
+perspective-viewer#workspace {
+  flex-grow: 1;
+  min-height: 0;
+}
+
+perspective-viewer#workspace {
   font-family: "Roboto Mono";
   --open-settings-button--content: "expand_more";
   --close-settings-button--content: "expand_less";

--- a/js/src/js/components/perspective/layout.js
+++ b/js/src/js/components/perspective/layout.js
@@ -22,12 +22,12 @@ export const saveCustomLayout = (layout) => {
  */
 export const stripTransientFields = (layout) => {
   const cloned = structuredClone(layout);
-  if (cloned?.viewers) {
-    Object.values(cloned.viewers).forEach((viewer) => {
-      delete viewer.theme;
+  if (cloned?.panels) {
+    Object.values(cloned.panels).forEach((panel) => {
+      delete panel.theme;
       // Strip datagrid column width overrides from plugin_config
-      if (viewer.plugin_config?.columns) {
-        for (const col of Object.values(viewer.plugin_config.columns)) {
+      if (panel.plugin_config?.columns) {
+        for (const col of Object.values(panel.plugin_config.columns)) {
           delete col.column_size_override;
         }
       }
@@ -101,20 +101,12 @@ export const setUrlLayout = async (layout) => {
   );
 };
 
-/** Build an empty workspace layout shell that tables can be added into */
+/** Build an empty whole-element workspace config that panels can be added into */
 export const buildEmptyLayout = () => ({
-  sizes: [1],
-  detail: {
-    main: {
-      type: "tab-area",
-      widgets: [],
-      currentIndex: 0,
-    },
+  layout: {
+    type: "tab-layout",
+    tabs: [],
+    selected: 0,
   },
-  master: {
-    sizes: [],
-    widgets: [],
-  },
-  mode: "globalFilters",
-  viewers: {},
+  panels: {},
 });

--- a/js/src/js/components/perspective/tables.js
+++ b/js/src/js/components/perspective/tables.js
@@ -3,7 +3,6 @@ import perspective_viewer from "@perspective-dev/viewer";
 import SERVER_WASM from "@perspective-dev/server/dist/wasm/perspective-server.wasm";
 import CLIENT_WASM from "@perspective-dev/viewer/dist/wasm/perspective-viewer.wasm";
 
-import "@perspective-dev/workspace";
 import "@perspective-dev/viewer-datagrid";
 import "@perspective-dev/viewer-charts";
 

--- a/js/src/js/components/perspective/tables.js
+++ b/js/src/js/components/perspective/tables.js
@@ -53,5 +53,10 @@ export const fetchTables = async () => {
     return acc;
   }, {});
 
-  return { worker, websocket, tables: new_tables };
+  return {
+    worker,
+    websocket,
+    tables: new_tables,
+    defaultLayoutTables: meta.default_layout_tables ?? table_names,
+  };
 };

--- a/js/src/js/components/perspective/workspace.jsx
+++ b/js/src/js/components/perspective/workspace.jsx
@@ -21,8 +21,9 @@ import { getCurrentTheme, getViewerTheme } from "./theme";
 /**
  * Self-contained Perspective workspace component.
  *
- * Uses the raw <perspective-workspace> custom element directly
- * to control the exact order of load() → restore().
+ * Uses the raw <perspective-viewer> custom element directly, which in Perspective 5 hosts the
+ * multi-panel layout that <perspective-workspace> used to provide, so we control the exact order
+ * of load() -> restoreWorkspace().
  *
  * Exposes imperative methods via ref:
  *   - getLayouts()       → current layouts map
@@ -62,7 +63,7 @@ export const Workspace = forwardRef(function Workspace(
         try {
           clearViewerSelections(ws);
           await flushWorkspace(ws);
-          await ws.restore(themedLayout);
+          await ws.restoreWorkspace(themedLayout);
           await flushWorkspace(ws);
           if (syncUrl && generation === restoreGenerationRef.current) {
             await setUrlLayout(themedLayout);
@@ -120,7 +121,7 @@ export const Workspace = forwardRef(function Workspace(
         await restoreQueueRef.current.catch(() => {});
         const ws = wsRef.current;
         if (!ws) return;
-        const config = stripTransientFields(await ws.save());
+        const config = stripTransientFields(await ws.saveWorkspace());
         saveCustomLayout(config);
         setLayouts((prev) => ({ ...prev, "Custom Layout": config }));
         setActiveLayoutName("Custom Layout");
@@ -129,7 +130,7 @@ export const Workspace = forwardRef(function Workspace(
         await restoreQueueRef.current.catch(() => {});
         const ws = wsRef.current;
         if (!ws) return null;
-        const config = stripTransientFields(await ws.save());
+        const config = stripTransientFields(await ws.saveWorkspace());
         return JSON.stringify(config).replace(
           /PERSPECTIVE_GENERATED_/g,
           "CSP_GATEWAY_GENERATED_",
@@ -166,8 +167,8 @@ export const Workspace = forwardRef(function Workspace(
         sortedNames.forEach((tableName, index) => {
           const { schema } = tables[tableName];
           const generated_id = `${tableName.toUpperCase()}_GENERATED_${index + 1}`;
-          defaultLayout.detail.main.widgets.push(generated_id);
-          defaultLayout.viewers[generated_id] = getDefaultViewerConfig(
+          defaultLayout.layout.tabs.push(generated_id);
+          defaultLayout.panels[generated_id] = getDefaultViewerConfig(
             tableName,
             schema,
             theme,
@@ -190,12 +191,12 @@ export const Workspace = forwardRef(function Workspace(
       };
       if (cancelled) return;
 
-      // 4. CRITICAL: load client FIRST, then restore layout
+      // 4. CRITICAL: load clients FIRST, then restore layout
       //    Load local worker first (has client-server tables as local copies).
       //    Load websocket second (for server-only tables).
-      //    The workspace iterates clients in order, so client-server tables
-      //    will match on the local worker, giving each viewer an independent
-      //    local table (no shared views / no scroll sync between viewers).
+      //    The viewer resolves a panel's `table` name across every loaded client in order, so
+      //    client-server tables match on the local worker, giving each panel an independent
+      //    local table (no shared views / no scroll sync between panels).
       await ws.load(worker);
       if (websocket !== worker) {
         await ws.load(websocket);
@@ -212,10 +213,10 @@ export const Workspace = forwardRef(function Workspace(
       initializedRef.current = true;
 
       // 7. Sync layout to URL on every workspace change
-      ws.addEventListener("workspace-layout-update", async () => {
+      ws.addEventListener("perspective-config-update", async () => {
         if (!initializedRef.current || restoringRef.current) return;
         try {
-          const config = stripTransientFields(await ws.save());
+          const config = stripTransientFields(await ws.saveWorkspace());
           if (!restoringRef.current) {
             await setUrlLayout(config);
           }
@@ -235,43 +236,22 @@ export const Workspace = forwardRef(function Workspace(
     };
   }, []);
 
-  // Apply theme to newly added viewers (right-click → add table)
-  // Only fires AFTER initial restore is complete (guarded by initializedRef)
-  // so it doesn't race with the bootstrap sequence.
-  useEffect(() => {
-    const ws = wsRef.current;
-    if (!ws) return;
-
-    const onNewView = ({ detail: { widget } }) => {
-      if (!initializedRef.current || restoringRef.current) return;
-      if (widget?.viewer) {
-        const theme = getCurrentTheme();
-        widget.viewer.setAttribute("theme", getViewerTheme(theme));
-      }
-    };
-
-    ws.addEventListener("workspace-new-view", onNewView);
-    return () => ws.removeEventListener("workspace-new-view", onNewView);
-  }, []);
-
-  return <perspective-workspace id="workspace" ref={wsRef} />;
+  // Theme is element-level in Perspective 5, so panels added later inherit it from the viewer and
+  // no per-panel hook is needed; `applyTheme` restores it across every mounted viewer.
+  return <perspective-viewer id="workspace" ref={wsRef} />;
 });
 
-/** Clone a layout config and fill in missing viewer themes */
+/** Clone a layout config and fill in missing panel themes */
 function applyThemeToLayout(layout) {
   const theme = getCurrentTheme();
   const cloned = structuredClone(layout);
-  if (cloned?.viewers) {
-    Object.keys(cloned.viewers).forEach((id) => {
-      if (!cloned.viewers[id].theme) {
-        cloned.viewers[id].theme = getViewerTheme(theme);
+  if (cloned?.panels) {
+    Object.values(cloned.panels).forEach((panel) => {
+      if (!panel.theme) {
+        panel.theme = getViewerTheme(theme);
       }
-    });
-  }
-  if (cloned?.viewers) {
-    Object.values(cloned.viewers).forEach((viewer) => {
-      viewer.plugin_config = {
-        ...viewer.plugin_config,
+      panel.plugin_config = {
+        ...panel.plugin_config,
         edit_mode: "SELECT_REGION",
       };
     });
@@ -279,15 +259,13 @@ function applyThemeToLayout(layout) {
   return cloned;
 }
 
-function clearViewerSelections(workspace) {
-  for (const viewer of workspace.querySelectorAll("perspective-viewer")) {
-    try {
-      if (viewer.getSelection?.()) {
-        viewer.setSelection?.();
-      }
-    } catch {
-      // The viewer may already be mid-delete during a rapid restore.
+function clearViewerSelections(viewer) {
+  try {
+    if (viewer.getSelection?.()) {
+      viewer.setSelection?.();
     }
+  } catch {
+    // The viewer may already be mid-delete during a rapid restore.
   }
 }
 
@@ -295,7 +273,7 @@ async function flushWorkspace(workspace) {
   try {
     await workspace.flush?.();
   } catch {
-    // Perspective can reject stale viewer flushes while replacing layouts.
+    // Perspective can reject stale panel flushes while replacing layouts.
   }
 }
 

--- a/js/src/js/components/perspective/workspace.jsx
+++ b/js/src/js/components/perspective/workspace.jsx
@@ -153,7 +153,8 @@ export const Workspace = forwardRef(function Workspace(
 
     (async () => {
       // 1. Fetch tables from perspective server
-      const { worker, websocket, tables } = await fetchTables();
+      const { worker, websocket, tables, defaultLayoutTables } =
+        await fetchTables();
       if (cancelled) return;
 
       // 2. Build default layout from tables
@@ -163,8 +164,10 @@ export const Workspace = forwardRef(function Workspace(
       if (processTables) {
         processTables(defaultLayout, tables, theme);
       } else {
-        const sortedNames = Object.keys(tables).sort();
-        sortedNames.forEach((tableName, index) => {
+        // The server decides which tables the generated layout opens; tabs share the strip's width,
+        // so opening every table makes each label unreadable.
+        const openNames = defaultLayoutTables.filter((name) => name in tables);
+        openNames.forEach((tableName, index) => {
           const { schema } = tables[tableName];
           const generated_id = `${tableName.toUpperCase()}_GENERATED_${index + 1}`;
           defaultLayout.layout.tabs.push(generated_id);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ server = [
     "pydantic>=2",
     # Default frontend provider (Settings.UI_PROVIDER = "spaday"). 0.4 tracks perspective 5.
     "spaday>=0.7.1",
-    "spaday-perspective>=0.4.0",
+    "spaday-perspective>=0.4.1",
     "spaday-webawesome>=0.2.0",
     "uvicorn>=0.28.1,<0.50",
     "uvloop",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,13 +95,13 @@ server = [
     "janus",
     "omegaconf",
     "orjson",
-    "perspective-python>=4.5,<4.6",
+    "perspective-python>=5.2,<6",
     "psutil",
     "pyarrow",
     "pydantic>=2",
-    # Default frontend provider (Settings.UI_PROVIDER = "spaday").
+    # Default frontend provider (Settings.UI_PROVIDER = "spaday"). 0.4 tracks perspective 5.
     "spaday>=0.7.1",
-    "spaday-perspective>=0.2.0",
+    "spaday-perspective>=0.4.0",
     "spaday-webawesome>=0.2.0",
     "uvicorn>=0.28.1,<0.50",
     "uvloop",


### PR DESCRIPTION
## Description

Upgrades Perspective from 4.5 to 5.2 across the Python dependency, both frontends, and the saved-layout format.

Perspective 5 deprecated `@perspective-dev/workspace` and folded it into `<perspective-viewer>`, which now hosts the multi-panel layout (`addPanel` / `removePanel` / `getPanelNames` / `saveWorkspace` / `restoreWorkspace`). That changes the layout envelope from a Lumino widget tree plus a `viewers` map to a layout tree plus a `panels` map.

- `perspective-python>=5.2,<6`, `spaday-perspective>=0.4.1` (the release that applies whole-element configs through `restoreWorkspace`).
- **Saved layouts migrate automatically.** `layouts` entries are configured server side and served to whichever frontend is mounted, so an existing entry would otherwise silently fail to restore. The envelope is rewritten on the way in — from the field validator for configured layouts, and at merge time for `layouts_field` ones. Per-panel bodies are untouched: the viewer migrates those itself from the `version` each carries. Layouts already in the version 5 shape, and anything unparseable, pass through, so it is safe to run on every layout at every startup.
- The spaday provider's generated all-tables view now emits a version 5 config; it was still emitting a version 4 one, which left every panel unbound.
- The legacy React UI is ported off `@perspective-dev/workspace`.
- The generated default layout now opens a bounded set of tables (see below).

### Per-table client/server architecture is preserved

`load()` accumulates clients rather than replacing them — a viewer resolves each panel's `table` name across every client loaded into it. Verified with two genuinely separate engines:

```
clientA === clientB: false
clientA sees table_two: no (separate engines)
clientB sees table_one: no (separate engines)
panel(table_one): 3 rows, cols a      <- resolved from clientA
panel(table_two): 2 rows, cols b      <- resolved from clientB
```

So the legacy UI still loads the local worker first and the websocket second, and `client-server` tables keep their independent local copy. (The `load` docstring says "will use **this** `Client`", which reads like replacement — it is not.)

### New: bounding the generated layout

Perspective 5 lays the tab strip out as an equal-width grid, so every extra tab narrows the rest. Opening one tab per table left the omnibus demo with eleven tabs captioned with a single character each; the old Lumino tab bar sized tabs to their content, which is why this only surfaces now.

- `default_layout_max_tables` (default `5`) — how many tables the generated layout opens, in name order.
- `default_layout_tables` — name them explicitly instead, in display order.

Neither restricts what is available: every table is still hosted and can be added by hand. The selection is served from the perspective meta endpoint so both frontends generate the same default.

## Verification

Driven in a browser against the omnibus demo on both providers:

- spaday: all eleven tables bind, rows flow (`server_view` 163, `basket` 2480), a migrated version 4 layout restores as a `split-layout` with all four panels bound.
- legacy: five readable tabs with the datagrid streaming; `basket` is `architecture: server` and is never mirrored into the worker, so its rendering confirms both clients are being searched.

## Type of Change

- [x] New feature
- [x] Other (describe below)

Major dependency upgrade. Two behaviour notes for the release:

- Saved layouts are migrated automatically, but the `processTables` customization hook receives the layout object, so anyone injecting panels through it must move from `detail.main.widgets` / `viewers` to `layout.tabs` / `panels`.
- The generated default layout now opens at most five tables rather than all of them.

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [ ] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)
