### PR TITLE
Move from httpx to httpx2

### DIFF
--- a/csp_gateway/client/client.py
+++ b/csp_gateway/client/client.py
@@ -19,8 +19,8 @@ from importlib import import_module
 from threading import Thread
 from typing import TYPE_CHECKING, Any, Literal, Union, cast
 
-import httpx
-from httpx import AsyncClient as httpx_AsyncClient, Response, get as GET, patch as PATCH, post as POST, put as PUT
+import httpx2
+from httpx2 import AsyncClient as httpx2_AsyncClient, Response, get as GET, patch as PATCH, post as POST, put as PUT
 from jsonref import replace_refs
 from nest_asyncio import apply as applyAsyncioNesting
 from packaging import version
@@ -394,7 +394,7 @@ class BaseGatewayClient(BaseModel):
     config: GatewayClientConfig = Field(default_factory=GatewayClientConfig)
 
     http_args: dict[str, Any] = Field(
-        default={"follow_redirects": True}, description="Additional arguments to pass to httpx requests (e.g., headers, auth, etc.)"
+        default={"follow_redirects": True}, description="Additional arguments to pass to httpx2 requests (e.g., headers, auth, etc.)"
     )
 
     # Additional initialization for bearer_token
@@ -591,7 +591,7 @@ class BaseGatewayClient(BaseModel):
     ) -> ResponseType:
         params = params or {}
         resolved_route, extra_params = self._buildroute(route)
-        async with httpx_AsyncClient() as client:
+        async with httpx2_AsyncClient() as client:
             return self._handle_response(
                 await client.get(resolved_route, params={**params, **extra_params}, timeout=timeout, **self.http_args), route=route
             )
@@ -618,7 +618,7 @@ class BaseGatewayClient(BaseModel):
     ) -> ResponseType:
         params = params or {}
         resolved_route, extra_params = self._buildroute(route)
-        async with httpx_AsyncClient() as client:
+        async with httpx2_AsyncClient() as client:
             return self._handle_response(
                 await client.post(resolved_route, params={**params, **extra_params}, json=data, timeout=timeout, **self.http_args), route=route
             )
@@ -635,7 +635,7 @@ class BaseGatewayClient(BaseModel):
         kwargs: dict[str, Any] = {"params": {**params, **extra_params}, "timeout": timeout, **self.http_args}
         if data is not None:
             kwargs["json"] = data
-        return self._handle_response(httpx.request("DELETE", resolved_route, **kwargs), route=route)
+        return self._handle_response(httpx2.request("DELETE", resolved_route, **kwargs), route=route)
 
     async def _deleteasync(
         self,
@@ -649,7 +649,7 @@ class BaseGatewayClient(BaseModel):
         kwargs: dict[str, Any] = {"params": {**params, **extra_params}, "timeout": timeout, **self.http_args}
         if data is not None:
             kwargs["json"] = data
-        async with httpx_AsyncClient() as client:
+        async with httpx2_AsyncClient() as client:
             return self._handle_response(await client.request("DELETE", resolved_route, **kwargs), route=route)
 
     def _patch(
@@ -670,7 +670,7 @@ class BaseGatewayClient(BaseModel):
     ) -> ResponseType:
         params = params or {}
         resolved_route, extra_params = self._buildroute(route)
-        async with httpx_AsyncClient() as client:
+        async with httpx2_AsyncClient() as client:
             return self._handle_response(
                 await client.patch(resolved_route, params={**params, **extra_params}, timeout=timeout, **self.http_args), route=route
             )
@@ -693,7 +693,7 @@ class BaseGatewayClient(BaseModel):
     ) -> ResponseType:
         params = params or {}
         resolved_route, extra_params = self._buildroute(route)
-        async with httpx_AsyncClient() as client:
+        async with httpx2_AsyncClient() as client:
             return self._handle_response(
                 await client.put(resolved_route, params={**params, **extra_params}, timeout=timeout, **self.http_args), route=route
             )

--- a/csp_gateway/server/middleware/oauth.py
+++ b/csp_gateway/server/middleware/oauth.py
@@ -6,7 +6,7 @@ from socket import gethostname
 from typing import Any
 from uuid import uuid4
 
-import httpx
+import httpx2
 from fastapi import APIRouter, Depends, HTTPException, Request, Security
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.security import OAuth2PasswordBearer
@@ -81,7 +81,7 @@ class MountOAuth2Middleware(AuthenticationMiddleware, IdentityAwareMiddlewareMix
 
         discovery_url = f"{self.issuer.rstrip('/')}/.well-known/openid-configuration"
         try:
-            response = httpx.get(discovery_url, verify=self.verify_ssl)
+            response = httpx2.get(discovery_url, verify=self.verify_ssl)
             response.raise_for_status()
             self._oidc_config = response.json()
             return self._oidc_config
@@ -118,7 +118,7 @@ class MountOAuth2Middleware(AuthenticationMiddleware, IdentityAwareMiddlewareMix
         if self.client_secret:
             data["client_secret"] = self.client_secret
 
-        async with httpx.AsyncClient(verify=self.verify_ssl) as client:
+        async with httpx2.AsyncClient(verify=self.verify_ssl) as client:
             response = await client.post(token_url, data=data)
             response.raise_for_status()
             return response.json()
@@ -126,7 +126,7 @@ class MountOAuth2Middleware(AuthenticationMiddleware, IdentityAwareMiddlewareMix
     async def _get_userinfo(self, access_token: str) -> dict[str, Any]:
         """Fetch user info from userinfo endpoint."""
         userinfo_url = self._get_userinfo_url()
-        async with httpx.AsyncClient(verify=self.verify_ssl) as client:
+        async with httpx2.AsyncClient(verify=self.verify_ssl) as client:
             response = await client.get(
                 userinfo_url,
                 headers={"Authorization": f"Bearer {access_token}"},
@@ -151,7 +151,7 @@ class MountOAuth2Middleware(AuthenticationMiddleware, IdentityAwareMiddlewareMix
         else:
             data["client_id"] = self.client_id
 
-        async with httpx.AsyncClient(verify=self.verify_ssl) as client:
+        async with httpx2.AsyncClient(verify=self.verify_ssl) as client:
             response = await client.post(introspection_url, data=data, auth=auth)
             response.raise_for_status()
             return response.json()

--- a/csp_gateway/tests/client/test_csp_stream.py
+++ b/csp_gateway/tests/client/test_csp_stream.py
@@ -413,15 +413,15 @@ def _run_gateway_for_csp_stream(port_str):
 
 def _wait_for_server(url: str, timeout: int = 30):
     """Wait for the server to be ready."""
-    import httpx
+    import httpx2
 
     start = time.time()
     while time.time() - start < timeout:
         try:
-            resp = httpx.get(url, timeout=1, follow_redirects=True)
+            resp = httpx2.get(url, timeout=1, follow_redirects=True)
             resp.raise_for_status()
             return True
-        except (httpx.HTTPStatusError, httpx.TransportError):
+        except (httpx2.HTTPStatusError, httpx2.TransportError):
             time.sleep(0.5)
     return False
 
@@ -484,11 +484,11 @@ def test_stream_csp_integration_subscribe_and_receive(csp_stream_free_port):
 
     finally:
         # Shutdown the gateway
-        import httpx
+        import httpx2
 
         try:
-            httpx.post(shutdown_url, timeout=1, follow_redirects=True)
-        except httpx.RequestError as e:
+            httpx2.post(shutdown_url, timeout=1, follow_redirects=True)
+        except httpx2.RequestError as e:
             logger.debug("Error shutting down gateway during test cleanup: %s", e)
         p.join(timeout=10)
         if p.is_alive():
@@ -560,11 +560,11 @@ def test_stream_csp_integration_dynamic_subscribe_unsubscribe(csp_stream_free_po
 
     finally:
         # Shutdown the gateway
-        import httpx
+        import httpx2
 
         try:
-            httpx.post(shutdown_url, timeout=1, follow_redirects=True)
-        except httpx.RequestError as e:
+            httpx2.post(shutdown_url, timeout=1, follow_redirects=True)
+        except httpx2.RequestError as e:
             logger.debug("Error shutting down gateway during test cleanup: %s", e)
         p.join(timeout=10)
         if p.is_alive():

--- a/csp_gateway/tests/server/gateway/test_gateway_start_stop.py
+++ b/csp_gateway/tests/server/gateway/test_gateway_start_stop.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import csp.impl.error_handling
-import httpx
+import httpx2
 import pytest
 from fastapi.testclient import TestClient
 
@@ -169,10 +169,10 @@ def test_signal_with_shutdown(signal_val, free_port):
             assert p.exitcode == 0
         try:
             time.sleep(REQUEST_RETRY_TIMEOUT)
-            resp = httpx.get(url, timeout=1, follow_redirects=True)
+            resp = httpx2.get(url, timeout=1, follow_redirects=True)
             resp.raise_for_status()
             break
-        except (httpx.HTTPStatusError, httpx.TransportError):
+        except (httpx2.HTTPStatusError, httpx2.TransportError):
             pass
 
     print("Server is up")
@@ -214,16 +214,16 @@ def test_shutdown_with_big_red_button(free_port):
             assert p.exitcode == 0
         try:
             time.sleep(REQUEST_RETRY_TIMEOUT)
-            resp = httpx.get(state_url, timeout=1, follow_redirects=True)
+            resp = httpx2.get(state_url, timeout=1, follow_redirects=True)
             resp.raise_for_status()
             break
-        except (httpx.HTTPStatusError, httpx.TransportError):
+        except (httpx2.HTTPStatusError, httpx2.TransportError):
             print("Server not up yet")
             continue
     print("Server is up")
     # Send signal to invoke shutdown
     print("Sending Shutdown Request")
-    resp = httpx.post(shutdown_url, timeout=1, follow_redirects=True)
+    resp = httpx2.post(shutdown_url, timeout=1, follow_redirects=True)
     # Wait for gateway to react to signal
     p.join(AFTER_SHUTDOWN_WAIT_TIME)
     # Check if gateway shutdown with proper exit status

--- a/csp_gateway/tests/server/web/test_oauth.py
+++ b/csp_gateway/tests/server/web/test_oauth.py
@@ -67,7 +67,7 @@ class TestOAuth2OIDCDiscovery:
             client_id="my-client-id",
         )
 
-        with patch("httpx.get") as mock_get:
+        with patch("httpx2.get") as mock_get:
             mock_response = MagicMock()
             mock_response.json.return_value = MOCK_OIDC_CONFIG
             mock_response.raise_for_status = MagicMock()
@@ -88,7 +88,7 @@ class TestOAuth2OIDCDiscovery:
             client_id="my-client-id",
         )
 
-        with patch("httpx.get") as mock_get:
+        with patch("httpx2.get") as mock_get:
             mock_response = MagicMock()
             mock_response.json.return_value = MOCK_OIDC_CONFIG
             mock_response.raise_for_status = MagicMock()
@@ -143,7 +143,7 @@ class TestOAuth2TokenExchange:
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("httpx.AsyncClient") as mock_client:
+        with patch("httpx2.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__.return_value = mock_instance
@@ -176,7 +176,7 @@ class TestOAuth2UserInfo:
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("httpx.AsyncClient") as mock_client:
+        with patch("httpx2.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.get = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__.return_value = mock_instance
@@ -208,7 +208,7 @@ class TestOAuth2TokenIntrospection:
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("httpx.AsyncClient") as mock_client:
+        with patch("httpx2.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.post = AsyncMock(return_value=mock_response)
             mock_client.return_value.__aenter__.return_value = mock_instance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ develop = [
     # client
     "aiohttp",
     "aiostream",
-    "httpx",
+    "httpx2",
     "jsonref",
     "nest-asyncio",
     "packaging",
@@ -90,7 +90,7 @@ server = [
     "duckdb>=1.4.1",
     "fastapi>=0.110",
     "fsspec",
-    "httpx",
+    "httpx2",
     "hydra-core",
     "janus",
     "omegaconf",
@@ -109,7 +109,7 @@ server = [
 ]
 client = [
     # NOTE: Optional
-    "httpx",
+    "httpx2",
     "jsonref",
     "nest-asyncio",
     "packaging",


### PR DESCRIPTION
## Description

Starlette's test client now prefers `httpx2` and emits a `StarletteDeprecationWarning` when it falls back to `httpx`:

```python
try:
    import httpx2 as httpx
except ModuleNotFoundError:
    try:
        import httpx
    except ModuleNotFoundError:
        raise RuntimeError("The starlette.testclient module requires the httpx2 package to be installed.")
    warnings.warn("Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.")
```

`httpx2` is the successor rather than a drop-in — it installs under its own import name — so this moves every reference, not just the requirement.

The surface we use carries over unchanged: the `verify` argument the OAuth middleware passes (`ssl.SSLContext | str | bool = True`), and the `RequestError` / `TransportError` / `HTTPStatusError` types the client catches, along with `AsyncClient`, `Response`, `request`, `get`, `post`, `put` and `patch`.

Updated in the `server` dependencies and the `client` and `develop` extras.

## Type of Change

- [x] Other (describe below)

Dependency swap. `csp-gateway[client]` now pulls `httpx2` instead of `httpx`, so anything importing `httpx` alongside it should declare that itself.

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [ ] New tests added for new functionality
- [ ] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)
