### PR TITLE
Add Spaday default layout hook

### DIFF
--- a/TODO_SPADAY.md
+++ b/TODO_SPADAY.md
@@ -30,3 +30,12 @@ Upstream action:
 - Bundle and register `@perspective-dev/viewer-charts` with `<perspective-panel>`, or expose a documented package/option that does so.
 - Add a browser test that restores a multi-panel workspace containing Datagrid, `X Bar`, and `Treemap`, then verifies `saveWorkspace()` retains each requested plugin.
 - Keep chart and Perspective viewer versions aligned so plugin registration uses the same Perspective runtime.
+
+## Expose initial Perspective readiness
+
+Applications with branded startup overlays need a stable signal that `<perspective-panel>` has connected, loaded its tables, and applied its initial workspace config. `perspective-config-update` currently works as an indirect signal, but it describes configuration changes rather than lifecycle readiness and may never fire when initialization fails.
+
+Upstream action:
+
+- Emit a one-shot `perspective-ready` event after the initial config has been applied and rendered.
+- Emit or expose initialization failures so hosts can replace a loader with an error state.

--- a/csp_gateway/server/modules/web/perspective.py
+++ b/csp_gateway/server/modules/web/perspective.py
@@ -735,6 +735,10 @@ class MountPerspectiveTables(GatewayModule):
             return [name for name in self.default_layout_tables if name in known]
         return sorted(names)[: self.default_layout_max_tables]
 
+    def build_default_ui_layout(self, tables: dict[str, dict[str, str]]) -> dict[str, Any] | None:
+        """Return a custom default Spaday workspace layout, or `None` to use the generated layout."""
+        return None
+
     def ui(self, app: "GatewayUI") -> None:
         # Register the Perspective workspace as the main panel of the spaday UI. Data rides
         # Perspective's own websocket (mounted by rest() at {API_STR}/perspective); the spaday
@@ -751,6 +755,7 @@ class MountPerspectiveTables(GatewayModule):
                 default_tables=self._select_default_layout_tables(tables),
                 layouts=layouts,
                 schemas=tables,
+                default_layout=self.build_default_ui_layout(tables),
             ),
         )
         default_view = self.default_layout or "__default__"

--- a/csp_gateway/server/web/spaday_ui.py
+++ b/csp_gateway/server/web/spaday_ui.py
@@ -285,19 +285,18 @@ class GatewayUI:
         default_tables: list[str] | None = None,
         layouts: dict[str, str] | None = None,
         schemas: dict[str, dict[str, str]] | None = None,
+        default_layout: dict[str, Any] | None = None,
     ) -> Any:
         """A Perspective workspace panel (the primary data view), bound to the theme + `view` state.
 
         Data rides Perspective's own websocket at ``route``; the panel only carries the workspace
-        layout/theme config. ``default_tables`` are the ones the generated layout opens, defaulting
-        to all of ``tables``. ``schemas`` (table name -> column name -> type) lets the generated
-        layout apply per-table defaults (timestamp sort, hidden id column). Add it to `Region.MAIN`.
+        layout/theme config. ``default_layout`` replaces the generated initial layout when supplied.
+        Otherwise ``default_tables`` are the ones the generated layout opens, defaulting to all of
+        ``tables``. ``schemas`` (table name -> column name -> type) lets the generated layout apply
+        per-table defaults (timestamp sort, hidden id column). Add it to `Region.MAIN`.
         """
         tables = list(tables or [])
-        default_layout = self._default_layout(
-            list(default_tables) if default_tables is not None else tables,
-            schemas=schemas,
-        )
+        default_layout = default_layout or self._default_layout(list(default_tables) if default_tables is not None else tables, schemas=schemas)
         layout_expr: Any = default_layout
         for name, layout_json in (layouts or {}).items():
             try:

--- a/csp_gateway/tests/server/web/test_spaday_ui.py
+++ b/csp_gateway/tests/server/web/test_spaday_ui.py
@@ -270,6 +270,23 @@ class TestDefaultLayout:
         assert "sort" not in panel
         assert "columns" not in panel
 
+    def test_custom_default_layout_replaces_generated_layout(self):
+        from csp_gateway.server.web.spaday_ui import GatewayUI
+
+        ui = object.__new__(GatewayUI)
+        ui._store_seeds = {}
+        ui._settings = GatewaySettings()
+        custom = {
+            "layout": {"type": "tab-layout", "tabs": ["custom"]},
+            "panels": {"custom": {"table": "orders", "plugin": "X Bar"}},
+        }
+
+        panel = ui.perspective_panel(route="/perspective", tables=["orders"], default_layout=custom)
+        node = panel.to_node()
+
+        assert "X Bar" in json.dumps(node)
+        assert "CSP_GATEWAY_0" not in json.dumps(node)
+
 
 class TestDarkBoot:
     """The page seeds `dark` from the browser's prefers-color-scheme, like the legacy UI."""


### PR DESCRIPTION
## Description

Allow downstream `MountPerspectiveTables` subclasses to provide a custom Perspective 5 default workspace through `build_default_ui_layout()`. This replaces downstream browser-side `processTables` callbacks with a server-authored layout while preserving the generated layout as the default behavior.

Document the upstream request for a first-class `perspective-ready` lifecycle event so branded loaders do not need to infer readiness from a configuration update.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes
- [x] Targeted tests pass (17)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)