### PR TITLE
Use spaday-perspective 0.4.5 fixes

### DIFF
--- a/csp_gateway/server/web/spaday_ui.py
+++ b/csp_gateway/server/web/spaday_ui.py
@@ -91,11 +91,6 @@ _GATEWAY_COMPONENT_PACKAGE = ComponentPackage(
     assets_dir=Path(__file__).with_name("spaday_assets"),
     assets=(("js", "actions.js"),),
 )
-_PERSPECTIVE_CHARTS_PACKAGE = ComponentPackage(
-    name="csp-gateway-perspective-charts",
-    assets_dir=Path(__file__).parents[1] / "build",
-    assets=(("js", "spaday-charts.js"),),
-)
 
 
 # Page-level resets that spaday's document template does not ship. The palette is deliberately absent:
@@ -780,7 +775,7 @@ class GatewayUI:
             scratch,
             self.build_page,
             # Component libraries ship as their own distributions and are resolved by entry point.
-            packages=["webawesome", "perspective", _GATEWAY_COMPONENT_PACKAGE, _PERSPECTIVE_CHARTS_PACKAGE],
+            packages=["webawesome", "perspective", _GATEWAY_COMPONENT_PACKAGE],
             # spaday infers "source checkout" from a `js/` dir next to itself, which any distribution
             # shipping a top-level `js/` package (plotly does) satisfies -- serving assets we consume
             # from the wheel, never from a spaday checkout.

--- a/csp_gateway/tests/server/web/test_spaday_ui.py
+++ b/csp_gateway/tests/server/web/test_spaday_ui.py
@@ -348,7 +348,6 @@ class TestSpadayPerspectiveLayoutActions:
     def test_layout_action_script_is_served(self, client: TestClient):
         page = client.get("/").text
         assert "/components/csp-gateway/actions.js" in page
-        assert "/components/csp-gateway-perspective-charts/spaday-charts.js" in page
         assert "globalThis.cspGatewayCustomLayout" in page
         assert '"gateway-workspace"' in client.get("/tree.json").text
         script = client.get("/components/csp-gateway/actions.js")
@@ -361,10 +360,6 @@ class TestSpadayPerspectiveLayoutActions:
         assert 'new Event("input", { bubbles: true })' in script.text
         assert '"gateway-workspace"' in script.text
         assert client.get("/js/cdn/index.js").status_code == 200
-        charts = client.get("/components/csp-gateway-perspective-charts/spaday-charts.js")
-        assert charts.status_code == 200
-        assert "X Bar" in charts.text
-        assert "Treemap" in charts.text
 
     def test_layout_download_is_a_same_origin_attachment(self, client: TestClient):
         layout = {"layout": {"type": "tab-layout", "tabs": []}, "panels": {}}

--- a/js/build.mjs
+++ b/js/build.mjs
@@ -30,10 +30,6 @@ const BUNDLES = [
     alias: REACT_ALIAS,
     publicPath: "static",
   },
-  {
-    entryPoints: ["./src/js/spaday_charts.js"],
-    outfile: "../csp_gateway/server/build/spaday-charts.js",
-  },
 ];
 
 const WASM_ASSETS = [

--- a/js/src/js/spaday_charts.js
+++ b/js/src/js/spaday_charts.js
@@ -1,1 +1,0 @@
-import "@perspective-dev/viewer-charts";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ server = [
     "pydantic>=2",
     # Default frontend provider (Settings.UI_PROVIDER = "spaday"). 0.4 tracks perspective 5.
     "spaday>=0.7.2",
-    "spaday-perspective>=0.4.3",
+    "spaday-perspective>=0.4.5",
     "spaday-webawesome>=0.2.0",
     "uvicorn>=0.28.1,<0.50",
     "uvloop",


### PR DESCRIPTION
spaday-perspective 0.4.5 now bundles Perspective chart plugins, restores background-panel themes concurrently, and emits explicit ready/error lifecycle events.