### PR TITLE
Upgrade legacy UI to Perspective 5.3

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -21,12 +21,12 @@
     "react-modern-drawer": "^1.4.0"
   },
   "devDependencies": {
-    "@perspective-dev/client": "~5.2.0",
-    "@perspective-dev/react": "~5.2.0",
-    "@perspective-dev/server": "~5.2.0",
-    "@perspective-dev/viewer": "~5.2.0",
-    "@perspective-dev/viewer-charts": "~5.2.0",
-    "@perspective-dev/viewer-datagrid": "~5.2.0",
+    "@perspective-dev/client": "~5.3.0",
+    "@perspective-dev/react": "~5.3.0",
+    "@perspective-dev/server": "~5.3.0",
+    "@perspective-dev/viewer": "~5.3.0",
+    "@perspective-dev/viewer-charts": "~5.3.0",
+    "@perspective-dev/viewer-datagrid": "~5.3.0",
     "cpy": "^13.2.2",
     "esbuild": "^0.28.0",
     "lightningcss": "^1.29.3",
@@ -36,12 +36,12 @@
     "react-dom": "19.2.6"
   },
   "peerDependencies": {
-    "@perspective-dev/client": "~5.2.0",
-    "@perspective-dev/react": "~5.2.0",
-    "@perspective-dev/server": "~5.2.0",
-    "@perspective-dev/viewer": "~5.2.0",
-    "@perspective-dev/viewer-charts": "~5.2.0",
-    "@perspective-dev/viewer-datagrid": "~5.2.0",
+    "@perspective-dev/client": "~5.3.0",
+    "@perspective-dev/react": "~5.3.0",
+    "@perspective-dev/server": "~5.3.0",
+    "@perspective-dev/viewer": "~5.3.0",
+    "@perspective-dev/viewer-charts": "~5.3.0",
+    "@perspective-dev/viewer-datagrid": "~5.3.0",
     "react": "19.2.6",
     "react-dom": "19.2.6"
   }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -20,23 +20,23 @@ importers:
         version: 1.4.0(react@19.2.6)
     devDependencies:
       '@perspective-dev/client':
-        specifier: ~5.2.0
-        version: 5.2.0
+        specifier: ~5.3.0
+        version: 5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       '@perspective-dev/react':
-        specifier: ~5.2.0
-        version: 5.2.0
+        specifier: ~5.3.0
+        version: 5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       '@perspective-dev/server':
-        specifier: ~5.2.0
-        version: 5.2.0
+        specifier: ~5.3.0
+        version: 5.3.0
       '@perspective-dev/viewer':
-        specifier: ~5.2.0
-        version: 5.2.0
+        specifier: ~5.3.0
+        version: 5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       '@perspective-dev/viewer-charts':
-        specifier: ~5.2.0
-        version: 5.2.0
+        specifier: ~5.3.0
+        version: 5.3.0
       '@perspective-dev/viewer-datagrid':
-        specifier: ~5.2.0
-        version: 5.2.0
+        specifier: ~5.3.0
+        version: 5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       cpy:
         specifier: ^13.2.2
         version: 13.2.2
@@ -229,23 +229,23 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@perspective-dev/client@5.2.0':
-    resolution: {integrity: sha512-zkJmJFwdw0wMREoJt8gUJyCsflzi7s7Yc8ZtUCOLE9XB6fdyxJmDB99cxO3Q+hno/57kLsz8VNoz8XSm6PZNrg==}
+  '@perspective-dev/client@5.3.0':
+    resolution: {integrity: sha512-41ITlb3PsgnmcG+icZWb+O+eyUnY2zyqrKJZFclCiEHOQXw9Yde1Ou/wVo3CLViPwM3OQQtT1BLuuG0zQdDy+A==}
 
-  '@perspective-dev/react@5.2.0':
-    resolution: {integrity: sha512-sTurmFFUtPytI3QZ9bH/dy89C6DEi5L3NqVO32ODbPZx+69woNcBbAyVkWSpLZBt0UUq2kzWlIuHuq9Yeh66HQ==}
+  '@perspective-dev/react@5.3.0':
+    resolution: {integrity: sha512-mS8Ws7LOBHLzWifskTMPTgrube27Yuxf6dU4OwkGR3wP26VaW7QRqv4Y3K3IvutDRAqrpEBEKy8sd+CEofDRrw==}
 
-  '@perspective-dev/server@5.2.0':
-    resolution: {integrity: sha512-WRBiokT2/BYM8Ipe7Dg1/2UYNb01Vsox79KBfFVI800VmwdId0GdqI95zufN5ZoFffeBfri1sr3S3AShBRFXKA==}
+  '@perspective-dev/server@5.3.0':
+    resolution: {integrity: sha512-CcPb05fVGGQu90JZSL7Y+JVAqE6VEVatz4JR5T1Fb8qjbDnOAEleygx60ce5lUIHfOQfYXR/cDglSR7BtiFcFQ==}
 
-  '@perspective-dev/viewer-charts@5.2.0':
-    resolution: {integrity: sha512-Gf0Vw4GmPU73d8r1jCxBQ/pAz1G2fbon3JIPU9BQI/Godz3l0MwrsMVicPgp/iLKHd6NU4l82KFRGDTBJVdbBQ==}
+  '@perspective-dev/viewer-charts@5.3.0':
+    resolution: {integrity: sha512-EOCpgqqyUm3oQOuXuAdG057QFEqjJkiAfnHmfAQwFuQ1wO/m/2B6CoFSdKb3/NwyXMJCUR4QldgMkr1fy8oDDw==}
 
-  '@perspective-dev/viewer-datagrid@5.2.0':
-    resolution: {integrity: sha512-v/SR/35YfyKfivO21nglJFiyG1iE5G8vMwIwWI6fQuwjW764pmNrm/zcrNWNY70x5XHkPRM94aY6LjkLsLkO2g==}
+  '@perspective-dev/viewer-datagrid@5.3.0':
+    resolution: {integrity: sha512-FSZ2mffYeMz+g4EHYTtuhkFKs0HsvT6vcb9zw2f17cxX0o6Ey5aKtZN9KJrvYOVYZjwh5AJK2dHWnzoJ0l7pwg==}
 
-  '@perspective-dev/viewer@5.2.0':
-    resolution: {integrity: sha512-IIyqdPduofzzZ/QWrteq29IadJQR8IapTRz7U6XbrtBBm7eyiFsIBKQV0wFfcqWg4TRnhuvCAUvBRieuE0R8Eg==}
+  '@perspective-dev/viewer@5.3.0':
+    resolution: {integrity: sha512-5h7++op0aJ7DOCyfBKc5B3y2Q+uq9hLS9ttooilRuvA+fFXWxtfInWPWA1Y8TWV0kH4dZQXiEBHfSfZibq8Jug==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -928,8 +928,8 @@ packages:
   regular-layout@0.6.1:
     resolution: {integrity: sha512-vGDEFACgFbS/d5kLWJ6AMWY/3DYaZoF1P8+y4KIDnPUFqUQgV5bV8avX7836izmexfmz6ik8JZ4V0Xo4FhaZGQ==}
 
-  regular-table@0.8.6:
-    resolution: {integrity: sha512-jzJzu9WLtqwMgbf5ak/VdNm/YLHUDnDSCHD5SOksnHrHLuDN6l5i2stYfe7BjsHbQV1Gx9369Ma40nTBCgOFvA==}
+  regular-table@0.9.0:
+    resolution: {integrity: sha512-SY3gZvEQqN0PdMsg77qJrWHxAWWx3kJsG4+PlskcL1zAPEczo42/95SdlDXe/S0KckqOJrChrpDjPE7RrRf5jQ==}
     engines: {node: '>=16'}
 
   requires-port@1.0.0:
@@ -1246,10 +1246,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@perspective-dev/client@5.2.0':
+  '@perspective-dev/client@5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@perspective-dev/server': 5.2.0
-      pro_self_extracting_wasm: 0.0.9
+      '@perspective-dev/server': 5.3.0
+      pro_self_extracting_wasm: 0.0.9(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       stoppable: 1.1.0
       ws: 8.20.1
     transitivePeerDependencies:
@@ -1258,10 +1258,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@perspective-dev/react@5.2.0':
+  '@perspective-dev/react@5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@perspective-dev/client': 5.2.0
-      '@perspective-dev/viewer': 5.2.0
+      '@perspective-dev/client': 5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      '@perspective-dev/viewer': 5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       '@types/react': 19.2.15
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -1271,25 +1271,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@perspective-dev/server@5.2.0': {}
+  '@perspective-dev/server@5.3.0': {}
 
-  '@perspective-dev/viewer-charts@5.2.0': {}
+  '@perspective-dev/viewer-charts@5.3.0': {}
 
-  '@perspective-dev/viewer-datagrid@5.2.0':
+  '@perspective-dev/viewer-datagrid@5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@perspective-dev/client': 5.2.0
-      '@perspective-dev/viewer': 5.2.0
-      regular-table: 0.8.6
+      '@perspective-dev/client': 5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      '@perspective-dev/viewer': 5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      regular-table: 0.9.0
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@perspective-dev/viewer@5.2.0':
+  '@perspective-dev/viewer@5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@perspective-dev/client': 5.2.0
-      pro_self_extracting_wasm: 0.0.9
+      '@perspective-dev/client': 5.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      pro_self_extracting_wasm: 0.0.9(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       regular-layout: 0.6.1
     transitivePeerDependencies:
       - bufferutil
@@ -1441,9 +1441,11 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   define-data-property@1.1.4:
     dependencies:
@@ -1596,7 +1598,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@7.2.0)
 
   for-each@0.3.5:
     dependencies:
@@ -1695,26 +1699,26 @@ snapshots:
     dependencies:
       whatwg-encoding: 2.0.0
 
-  http-proxy@1.18.1:
+  http-proxy@1.18.1(debug@4.4.3(supports-color@7.2.0)):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
 
-  http-server@14.1.1:
+  http-server@14.1.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       basic-auth: 2.0.1
       chalk: 4.1.2
       corser: 2.0.1
       he: 1.2.0
       html-encoding-sniffer: 3.0.0
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@7.2.0))
       mime: 1.6.0
       minimist: 1.2.8
       opener: 1.5.2
-      portfinder: 1.0.38
+      portfinder: 1.0.38(supports-color@7.2.0)
       secure-compare: 3.0.1
       union: 0.5.0
       url-join: 4.0.1
@@ -2009,10 +2013,10 @@ snapshots:
 
   pify@3.0.0: {}
 
-  portfinder@1.0.38:
+  portfinder@1.0.38(supports-color@7.2.0):
     dependencies:
       async: 3.2.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2020,9 +2024,9 @@ snapshots:
 
   prettier@3.8.4: {}
 
-  pro_self_extracting_wasm@0.0.9:
+  pro_self_extracting_wasm@0.0.9(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      http-server: 14.1.1
+      http-server: 14.1.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       leb128: 0.0.5
       zx: 8.8.5
     transitivePeerDependencies:
@@ -2078,7 +2082,7 @@ snapshots:
 
   regular-layout@0.6.1: {}
 
-  regular-table@0.8.6: {}
+  regular-table@0.9.0: {}
 
   requires-port@1.0.0: {}
 

--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -1,6 +1,14 @@
 allowBuilds:
   esbuild: true
 
+minimumReleaseAgeExclude:
+  - '@perspective-dev/client@5.3.0'
+  - '@perspective-dev/react@5.3.0'
+  - '@perspective-dev/server@5.3.0'
+  - '@perspective-dev/viewer-charts@5.3.0'
+  - '@perspective-dev/viewer-datagrid@5.3.0'
+  - '@perspective-dev/viewer@5.3.0'
+
 onlyBuiltDependencies:
   - esbuild
 


### PR DESCRIPTION
Bumps the `@perspective-dev` packages in the legacy React UI to `~5.3.0` (dev and peer dependencies).

Two notes from the upgrade:
- `viewer-datagrid` declares its `viewer` dependency as an empty range, so the stale lockfile kept a 5.2.0 copy resolved alongside 5.3.0 — two viewer copies in one bundle would double-register the `perspective-viewer` elements — so the lockfile is deduped to a single 5.3.0.
- pnpm's minimum-release-age gate required exclusions for the fresh 5.3.0 packages (`pnpm-workspace.yaml`).

`perspective-python` already allows 5.3 (`>=5.2,<6`), so no Python changes. Web test suite passes (239).